### PR TITLE
Wrapper 컴포넌트 padding 추가

### DIFF
--- a/frontend/src/components/Layout/Wrapper/Wrapper.styled.ts
+++ b/frontend/src/components/Layout/Wrapper/Wrapper.styled.ts
@@ -8,8 +8,13 @@ export const Container = styled.div<WrapperProps>`
   height: ${({ fullHeight }) => (fullHeight ? '100vh' : 'auto')};
   background-color: ${({ backgroundColor }) => backgroundColor ?? 'transparent'};
 
-  padding-top: ${({ paddingTop }) => paddingTop ?? '0'};
-  padding-right: ${({ paddingRight }) => paddingRight ?? '0'};
-  padding-bottom: ${({ paddingBottom }) => paddingBottom ?? '0'};
-  padding-left: ${({ paddingLeft }) => paddingLeft ?? '0'};
+  ${({ padding, paddingTop, paddingRight, paddingBottom, paddingLeft }) =>
+    padding
+      ? `padding: ${padding};`
+      : `
+          padding-top: ${paddingTop ?? '0'};
+          padding-right: ${paddingRight ?? '0'};
+          padding-bottom: ${paddingBottom ?? '0'};
+          padding-left: ${paddingLeft ?? '0'};
+        `}
 `;

--- a/frontend/src/components/Layout/Wrapper/Wrapper.styled.ts
+++ b/frontend/src/components/Layout/Wrapper/Wrapper.styled.ts
@@ -10,7 +10,7 @@ export const Container = styled.div<WrapperProps>`
 
   ${({ padding, paddingTop, paddingRight, paddingBottom, paddingLeft }) =>
     padding
-      ? `padding: ${padding};`
+      ? `padding: ${padding ?? '0'};`
       : `
           padding-top: ${paddingTop ?? '0'};
           padding-right: ${paddingRight ?? '0'};

--- a/frontend/src/components/Layout/Wrapper/index.tsx
+++ b/frontend/src/components/Layout/Wrapper/index.tsx
@@ -2,20 +2,12 @@ import React from 'react';
 import * as S from './Wrapper.styled';
 import { CSSPaddingVar } from '@/types/designTokenType';
 
-type paddingUnit = CSSPaddingVar | 0;
-
-export type CSSPaddingShorthand =
-  | `${paddingUnit}`
-  | `${paddingUnit} ${paddingUnit}`
-  | `${paddingUnit} ${paddingUnit} ${paddingUnit}`
-  | `${paddingUnit} ${paddingUnit} ${paddingUnit} ${paddingUnit}`;
-
 export interface WrapperProps {
   maxWidth?: number | 'fit-content' | 'max-content' | 'min-content' | '100%' | 'auto';
   fullHeight?: boolean;
   backgroundColor?: string;
 
-  padding?: CSSPaddingShorthand;
+  padding?: CSSPaddingVar;
   paddingTop?: CSSPaddingVar;
   paddingRight?: CSSPaddingVar;
   paddingBottom?: CSSPaddingVar;

--- a/frontend/src/components/Layout/Wrapper/index.tsx
+++ b/frontend/src/components/Layout/Wrapper/index.tsx
@@ -2,11 +2,20 @@ import React from 'react';
 import * as S from './Wrapper.styled';
 import { CSSPaddingVar } from '@/types/designTokenType';
 
+type paddingUnit = CSSPaddingVar | 0;
+
+export type CSSPaddingShorthand =
+  | `${paddingUnit}`
+  | `${paddingUnit} ${paddingUnit}`
+  | `${paddingUnit} ${paddingUnit} ${paddingUnit}`
+  | `${paddingUnit} ${paddingUnit} ${paddingUnit} ${paddingUnit}`;
+
 export interface WrapperProps {
   maxWidth?: number | 'fit-content' | 'max-content' | 'min-content' | '100%' | 'auto';
   fullHeight?: boolean;
   backgroundColor?: string;
 
+  padding?: CSSPaddingShorthand;
   paddingTop?: CSSPaddingVar;
   paddingRight?: CSSPaddingVar;
   paddingBottom?: CSSPaddingVar;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#145 

## 📝 작업 내용

- Wrapper 스타일 속성에 padding 추가 

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

- 지금 Wrapper 컴포넌트 내부에 padding을 위한 타입이 선언되어 있는데 굳이 뺄 필요성은 없을 것 같아서 내부에 작성했습니다. 혹시 외부에 빼는 게 더 좋을까요?
