### PR TITLE
방 생성 페이지 상태 관리

### DIFF
--- a/frontend/src/components/Sections/BasicSettings/BasicSettings.stories.tsx
+++ b/frontend/src/components/Sections/BasicSettings/BasicSettings.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryFn } from '@storybook/react-webpack5';
 import BasicSettings from '.';
+import { useState } from 'react';
+import type { Field } from '@/types/field';
 
 export default {
   title: 'Components/BasicSettings',
@@ -7,7 +9,20 @@ export default {
   tags: ['autodocs'],
 } as Meta<typeof BasicSettings>;
 
-const Template: StoryFn<typeof BasicSettings> = (args) => <BasicSettings {...args} />;
+const Template: StoryFn = () => {
+  const [title, setTitle] = useState('');
+  const titleField: Field<string> = {
+    value: title,
+    set: setTitle,
+  };
+
+  const [time, setTime] = useState({ startTime: '', endTime: '' });
+  const timeField: Field<{ startTime: string; endTime: string }> = {
+    value: time,
+    set: setTime,
+  };
+
+  return <BasicSettings title={titleField} time={timeField} />;
+};
 
 export const Default = Template.bind({});
-Default.args = {};

--- a/frontend/src/components/Sections/BasicSettings/index.tsx
+++ b/frontend/src/components/Sections/BasicSettings/index.tsx
@@ -8,11 +8,13 @@ import useSelectTime from '@/hooks/useSelectTime';
 import ISun from '@/icons/ISun';
 import IMoon from '@/icons/IMoon';
 import { useTheme } from '@emotion/react';
+import { Field } from '@/types/field';
 
-//Todo: 페이지에서 상태를 내려줄 경우
-interface BasicSettingsProps {}
+type BasicSettingsProps = {
+  title: Field<string>;
+};
 
-const BasicSettings = ({}: BasicSettingsProps) => {
+const BasicSettings = ({ title }: BasicSettingsProps) => {
   const { colors } = useTheme();
 
   const { isOpen: isStartOpen, toggleOpen: toggleStartOpen } = useTimePicker();
@@ -36,7 +38,11 @@ const BasicSettings = ({}: BasicSettingsProps) => {
           <Text variant="body">참여자들에게 표시될 방의 제목을 입력해주세요.</Text>
         </S.TextWrapper>
         <S.InputWrapper>
-          <Input placeholder="예: 1팀 7월 정기 회의" />
+          <Input
+            placeholder="예: 1팀 7월 정기 회의"
+            value={title.value}
+            onChange={(e) => title.set(e.target.value)}
+          />
         </S.InputWrapper>
       </S.InfoWrapper>
       <S.InfoWrapper>

--- a/frontend/src/components/Sections/BasicSettings/index.tsx
+++ b/frontend/src/components/Sections/BasicSettings/index.tsx
@@ -12,9 +12,10 @@ import { Field } from '@/types/field';
 
 type BasicSettingsProps = {
   title: Field<string>;
+  time: Field<{ startTime: string; endTime: string }>;
 };
 
-const BasicSettings = ({ title }: BasicSettingsProps) => {
+const BasicSettings = ({ title, time }: BasicSettingsProps) => {
   const { colors } = useTheme();
 
   const { isOpen: isStartOpen, toggleOpen: toggleStartOpen } = useTimePicker();
@@ -28,7 +29,7 @@ const BasicSettings = ({ title }: BasicSettingsProps) => {
     handleCustomButtonClick,
     handleCustomStartClick,
     handleCustomEndClick,
-  } = useSelectTime();
+  } = useSelectTime({ timeRange: time.value, setTimeRange: time.set });
 
   return (
     <S.Container>

--- a/frontend/src/components/Sections/CalendarSettings/index.tsx
+++ b/frontend/src/components/Sections/CalendarSettings/index.tsx
@@ -1,26 +1,34 @@
 import Calender from '@/components/Calendar';
 import * as S from './CalendarSettings.styled';
-import { useState } from 'react';
 import { useDateSelection } from '@/hooks/Calendar/useDateSelection';
 import Text from '@/components/Text';
+import { Field } from '@/types/field';
 
-const CalendarSettings = () => {
+type CalendarSettingsProps = {
+  availableDates: Field<Set<string>>;
+};
+
+const CalendarSettings = ({ availableDates }: CalendarSettingsProps) => {
   const today = new Date();
-  const [selectedDates, setSelectedDates] = useState<Set<string>>(new Set());
-  const dateSelection = useDateSelection({ selectedDates, setSelectedDates, today });
+  const dateSelection = useDateSelection({
+    selectedDates: availableDates.value,
+    setSelectedDates: availableDates.set,
+    today,
+  });
   const mouseHandlers = {
     onMouseDown: dateSelection.onMouseDown,
     onMouseEnter: dateSelection.onMouseEnter,
     onMouseUp: dateSelection.onMouseUp,
     onMouseLeave: dateSelection.onMouseLeave,
   };
+
   return (
     <S.Container>
       <S.TextWrapper>
         <Text variant="h3">날짜 선택</Text>
         <Text variant="body">참여자들에게 드래그 해주세요! 뭐라카노</Text>
       </S.TextWrapper>
-      <Calender today={today} selectedDates={selectedDates} mouseHandlers={mouseHandlers} />
+      <Calender today={today} selectedDates={availableDates.value} mouseHandlers={mouseHandlers} />
     </S.Container>
   );
 };

--- a/frontend/src/components/Sections/OptionSettings/OptionSettings.stories.tsx
+++ b/frontend/src/components/Sections/OptionSettings/OptionSettings.stories.tsx
@@ -20,9 +20,9 @@ const Template: StoryFn = () => {
     set: setDeadLine,
   };
 
-  const [isPublic, setIsPublic] = useState<boolean>(true);
+  const [isPublic, setIsPublic] = useState<'public' | 'private'>('public');
 
-  const isPublicField: Field<boolean> = {
+  const isPublicField: Field<'public' | 'private'> = {
     value: isPublic,
     set: setIsPublic,
   };

--- a/frontend/src/components/Sections/OptionSettings/OptionSettings.stories.tsx
+++ b/frontend/src/components/Sections/OptionSettings/OptionSettings.stories.tsx
@@ -1,5 +1,7 @@
 import { Meta, StoryFn } from '@storybook/react-webpack5';
 import OptionSettings from '.';
+import { useState } from 'react';
+import type { Field } from '@/types/field';
 
 export default {
   title: 'Components/OptionSettings',
@@ -7,7 +9,25 @@ export default {
   tags: ['autodocs'],
 } as Meta<typeof OptionSettings>;
 
-const Template: StoryFn<typeof OptionSettings> = (args) => <OptionSettings {...args} />;
+const Template: StoryFn = () => {
+  const [deadLine, setDeadLine] = useState<{ date: string; time: string }>({
+    date: '2025-07-23',
+    time: '16:00',
+  });
+
+  const deadLineField: Field<{ date: string; time: string }> = {
+    value: deadLine,
+    set: setDeadLine,
+  };
+
+  const [isPublic, setIsPublic] = useState<boolean>(true);
+
+  const isPublicField: Field<boolean> = {
+    value: isPublic,
+    set: setIsPublic,
+  };
+
+  return <OptionSettings deadLine={deadLineField} isPublic={isPublicField} />;
+};
 
 export const Default = Template.bind({});
-Default.args = {};

--- a/frontend/src/components/Sections/OptionSettings/OptionSettings.stories.tsx
+++ b/frontend/src/components/Sections/OptionSettings/OptionSettings.stories.tsx
@@ -15,15 +15,12 @@ type Story = StoryObj<typeof OptionSettings>;
 export const Interactive: Story = {
   render: () => {
     const [isOpenAccordion, setIsOpenAccordion] = useState(false);
-    const [isDeadlineEnable, setisDeadlineEnable] = useState(false);
     const [date, setDate] = useState('2025-07-19');
 
     return (
       <OptionSettings
         isOpenAccordion={isOpenAccordion}
         onToggleAccordion={() => setIsOpenAccordion((prev) => !prev)}
-        isDeadlineEnable={isDeadlineEnable}
-        onToggleDeadline={() => setisDeadlineEnable((prev) => !prev)}
         date={date}
         onDateChange={(e) => setDate(e.target.value)}
       />

--- a/frontend/src/components/Sections/OptionSettings/OptionSettings.stories.tsx
+++ b/frontend/src/components/Sections/OptionSettings/OptionSettings.stories.tsx
@@ -14,16 +14,8 @@ type Story = StoryObj<typeof OptionSettings>;
 
 export const Interactive: Story = {
   render: () => {
-    const [isOpenAccordion, setIsOpenAccordion] = useState(false);
     const [date, setDate] = useState('2025-07-19');
 
-    return (
-      <OptionSettings
-        isOpenAccordion={isOpenAccordion}
-        onToggleAccordion={() => setIsOpenAccordion((prev) => !prev)}
-        date={date}
-        onDateChange={(e) => setDate(e.target.value)}
-      />
-    );
+    return <OptionSettings date={date} onDateChange={(e) => setDate(e.target.value)} />;
   },
 };

--- a/frontend/src/components/Sections/OptionSettings/OptionSettings.stories.tsx
+++ b/frontend/src/components/Sections/OptionSettings/OptionSettings.stories.tsx
@@ -1,21 +1,13 @@
-import { Meta, StoryObj } from '@storybook/react-webpack5';
-import { useState } from 'react';
+import { Meta, StoryFn } from '@storybook/react-webpack5';
 import OptionSettings from '.';
 
-const meta: Meta<typeof OptionSettings> = {
+export default {
   title: 'Components/OptionSettings',
   component: OptionSettings,
   tags: ['autodocs'],
-};
+} as Meta<typeof OptionSettings>;
 
-export default meta;
+const Template: StoryFn<typeof OptionSettings> = (args) => <OptionSettings {...args} />;
 
-type Story = StoryObj<typeof OptionSettings>;
-
-export const Interactive: Story = {
-  render: () => {
-    const [date, setDate] = useState('2025-07-19');
-
-    return <OptionSettings date={date} onDateChange={(e) => setDate(e.target.value)} />;
-  },
-};
+export const Default = Template.bind({});
+Default.args = {};

--- a/frontend/src/components/Sections/OptionSettings/index.tsx
+++ b/frontend/src/components/Sections/OptionSettings/index.tsx
@@ -12,7 +12,7 @@ import { Field } from '@/types/field';
 
 interface OptionSettingsProps {
   deadLine: Field<{ date: string; time: string }>;
-  isPublic: Field<boolean>;
+  isPublic: Field<'public' | 'private'>;
 }
 
 export interface StyleProps {
@@ -57,16 +57,16 @@ const OptionSettings = ({ deadLine, isPublic }: OptionSettingsProps) => {
         </S.Wrapper>
         <S.Wrapper flexDirection="column" gap="var(--gap-6)">
           <Text variant="h3">공개 범위</Text>
-          {ACCESS_OPTIONS.map(({ value, flag, label, Icon, description }) => (
+          {ACCESS_OPTIONS.map(({ value, label, Icon, description }) => (
             <S.Wrapper
               key={value}
-              onClick={() => isPublic.set(flag)}
+              onClick={() => isPublic.set(value)}
               border={`1px solid ${theme.colors.gray20}`}
               backgroundColor={theme.colors.gray10}
               padding={'var(--padding-7) var(--padding-4)'}
               borderRadius={'var(--radius-4)'}
             >
-              <Radio name="access" value={value} checked={isPublic.value === flag} readOnly>
+              <Radio name="access" value={value} checked={isPublic.value === value}>
                 <S.Wrapper gap="var(--gap-3)" alignItems="center">
                   <Icon color={theme.colors.text} />
                   <Text variant="h4">{label}</Text>

--- a/frontend/src/components/Sections/OptionSettings/index.tsx
+++ b/frontend/src/components/Sections/OptionSettings/index.tsx
@@ -12,6 +12,7 @@ import { Field } from '@/types/field';
 
 interface OptionSettingsProps {
   deadLine: Field<{ date: string; time: string }>;
+  isPublic: Field<boolean>;
 }
 
 export interface StyleProps {
@@ -25,7 +26,7 @@ export interface StyleProps {
   borderRadius?: string;
 }
 
-const OptionSettings = ({ deadLine }: OptionSettingsProps) => {
+const OptionSettings = ({ deadLine, isPublic }: OptionSettingsProps) => {
   const theme = useTheme();
   const { toggleOpen, isOpen } = useTimePicker();
   const [isOpenAccordion, setIsOpenAccordion] = useState(false);
@@ -56,15 +57,16 @@ const OptionSettings = ({ deadLine }: OptionSettingsProps) => {
         </S.Wrapper>
         <S.Wrapper flexDirection="column" gap="var(--gap-6)">
           <Text variant="h3">공개 범위</Text>
-          {ACCESS_OPTIONS.map(({ value, label, Icon, description }) => (
+          {ACCESS_OPTIONS.map(({ value, flag, label, Icon, description }) => (
             <S.Wrapper
               key={value}
+              onClick={() => isPublic.set(flag)}
               border={`1px solid ${theme.colors.gray20}`}
               backgroundColor={theme.colors.gray10}
               padding={'var(--padding-7) var(--padding-4)'}
               borderRadius={'var(--radius-4)'}
             >
-              <Radio name="access" value={value}>
+              <Radio name="access" value={value} checked={isPublic.value === flag} readOnly>
                 <S.Wrapper gap="var(--gap-3)" alignItems="center">
                   <Icon color={theme.colors.text} />
                   <Text variant="h4">{label}</Text>

--- a/frontend/src/components/Sections/OptionSettings/index.tsx
+++ b/frontend/src/components/Sections/OptionSettings/index.tsx
@@ -12,8 +12,6 @@ import useTimePicker from '@/hooks/useTimePicker';
 interface OptionSettingsProps {
   isOpenAccordion: boolean;
   onToggleAccordion: () => void;
-  isDeadlineEnable: boolean;
-  onToggleDeadline: () => void;
   date: string;
   onDateChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
@@ -32,8 +30,6 @@ export interface StyleProps {
 const OptionSettings = ({
   isOpenAccordion,
   onToggleAccordion,
-  isDeadlineEnable,
-  onToggleDeadline,
   date,
   onDateChange,
 }: OptionSettingsProps) => {
@@ -47,7 +43,6 @@ const OptionSettings = ({
         <S.Wrapper flexDirection="column" gap="var(--gap-6)">
           <S.Wrapper justifyContent="space-between">
             <Text variant="h3">마감 기한</Text>
-            <Toggle isOn={isDeadlineEnable} onToggle={onToggleDeadline} />
           </S.Wrapper>
           <S.Wrapper gap="var(--gap-2)">
             <DatePicker value={date} onChange={onDateChange} />

--- a/frontend/src/components/Sections/OptionSettings/index.tsx
+++ b/frontend/src/components/Sections/OptionSettings/index.tsx
@@ -8,10 +8,9 @@ import TimePicker from '@/components/Timepicker';
 import { useTheme } from '@emotion/react';
 import { ACCESS_OPTIONS } from '@/constants/optionsettings';
 import useTimePicker from '@/hooks/useTimePicker';
+import { useState } from 'react';
 
 interface OptionSettingsProps {
-  isOpenAccordion: boolean;
-  onToggleAccordion: () => void;
   date: string;
   onDateChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
@@ -27,19 +26,18 @@ export interface StyleProps {
   borderRadius?: string;
 }
 
-const OptionSettings = ({
-  isOpenAccordion,
-  onToggleAccordion,
-  date,
-  onDateChange,
-}: OptionSettingsProps) => {
+const OptionSettings = ({ date, onDateChange }: OptionSettingsProps) => {
   const theme = useTheme();
-
   const timePicker = useTimePicker();
+  const [isOpenAccordion, setIsOpenAccordion] = useState(false);
 
   return (
     <S.Container>
-      <Accordion title="선택 설정" isOpen={isOpenAccordion} onToggle={onToggleAccordion}>
+      <Accordion
+        title="선택 설정"
+        isOpen={isOpenAccordion}
+        onToggle={() => setIsOpenAccordion((prev) => !prev)}
+      >
         <S.Wrapper flexDirection="column" gap="var(--gap-6)">
           <S.Wrapper justifyContent="space-between">
             <Text variant="h3">마감 기한</Text>

--- a/frontend/src/components/Sections/OptionSettings/index.tsx
+++ b/frontend/src/components/Sections/OptionSettings/index.tsx
@@ -1,6 +1,5 @@
 import * as S from './OptionSettings.styled';
 import Text from '@/components/Text';
-import Toggle from '@/components/Toggle';
 import DatePicker from '@/components/DatePicker';
 import Radio from '@/components/Radio';
 import Accordion from '@/components/Accordion';
@@ -9,10 +8,10 @@ import { useTheme } from '@emotion/react';
 import { ACCESS_OPTIONS } from '@/constants/optionsettings';
 import useTimePicker from '@/hooks/useTimePicker';
 import { useState } from 'react';
+import { Field } from '@/types/field';
 
 interface OptionSettingsProps {
-  date: string;
-  onDateChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  deadLine: Field<{ date: string; time: string }>;
 }
 
 export interface StyleProps {
@@ -26,9 +25,9 @@ export interface StyleProps {
   borderRadius?: string;
 }
 
-const OptionSettings = ({ date, onDateChange }: OptionSettingsProps) => {
+const OptionSettings = ({ deadLine }: OptionSettingsProps) => {
   const theme = useTheme();
-  const timePicker = useTimePicker();
+  const { toggleOpen, isOpen } = useTimePicker();
   const [isOpenAccordion, setIsOpenAccordion] = useState(false);
 
   return (
@@ -43,8 +42,16 @@ const OptionSettings = ({ date, onDateChange }: OptionSettingsProps) => {
             <Text variant="h3">마감 기한</Text>
           </S.Wrapper>
           <S.Wrapper gap="var(--gap-2)">
-            <DatePicker value={date} onChange={onDateChange} />
-            <TimePicker {...timePicker} />
+            <DatePicker
+              value={deadLine.value.date}
+              onChange={(e) => deadLine.set({ date: e.target.value, time: deadLine.value.time })}
+            />
+            <TimePicker
+              selectedHour={deadLine.value.time}
+              selectHour={(hour: string) => deadLine.set({ date: deadLine.value.date, time: hour })}
+              toggleOpen={toggleOpen}
+              isOpen={isOpen}
+            />
           </S.Wrapper>
         </S.Wrapper>
         <S.Wrapper flexDirection="column" gap="var(--gap-6)">

--- a/frontend/src/components/Timepicker/index.tsx
+++ b/frontend/src/components/Timepicker/index.tsx
@@ -33,7 +33,11 @@ const TimePicker = ({ selectedHour, selectHour, toggleOpen, isOpen }: TimePicker
         <S.List role="listbox" isOpen={isOpen}>
           <S.ListItemWrapper>
             {hourOptions.map((time) => (
-              <S.ListItem key={time} role="option" onClick={(e) => selectHour(time, e)}>
+              <S.ListItem
+                key={time}
+                role="option"
+                onClick={(e) => selectHour(time.replace(/\s/g, ''), e)}
+              >
                 <Text variant="body"> {time}</Text>
               </S.ListItem>
             ))}

--- a/frontend/src/constants/optionsettings.ts
+++ b/frontend/src/constants/optionsettings.ts
@@ -1,17 +1,22 @@
 import IGlobe from '@/icons/IGlobe';
 import ILock from '@/icons/ILock';
 
-export const ACCESS_OPTIONS = [
+interface AccessOption {
+  value: 'public' | 'private';
+  Icon: React.FC<React.SVGProps<SVGSVGElement>>;
+  label: '공개' | '비공개';
+  description: '누구나 이 페이지에 접근할 수 있습니다.' | '링크를 가진 사람만 접근할 수 있습니다.';
+}
+
+export const ACCESS_OPTIONS: AccessOption[] = [
   {
     value: 'public',
-    flag: true,
     Icon: IGlobe,
     label: '공개',
     description: '누구나 이 페이지에 접근할 수 있습니다.',
   },
   {
     value: 'private',
-    flag: false,
     Icon: ILock,
     label: '비공개',
     description: '링크를 가진 사람만 접근할 수 있습니다.',

--- a/frontend/src/constants/optionsettings.ts
+++ b/frontend/src/constants/optionsettings.ts
@@ -4,12 +4,14 @@ import ILock from '@/icons/ILock';
 export const ACCESS_OPTIONS = [
   {
     value: 'public',
+    flag: true,
     Icon: IGlobe,
     label: '공개',
     description: '누구나 이 페이지에 접근할 수 있습니다.',
   },
   {
     value: 'private',
+    flag: false,
     Icon: ILock,
     label: '비공개',
     description: '링크를 가진 사람만 접근할 수 있습니다.',

--- a/frontend/src/hooks/useCreateRoom.ts
+++ b/frontend/src/hooks/useCreateRoom.ts
@@ -54,12 +54,23 @@ export const useCreateRoom = () => {
     set: (isPublic: boolean) => setRoomInfo((prev) => ({ ...prev, isPublic })),
   };
 
+  const isReadyToCreateRoom =
+    roomInfo.title.trim() !== '' &&
+    roomInfo.availableDates.size > 0 &&
+    roomInfo.time.startTime.trim() !== '' &&
+    roomInfo.time.endTime.trim() !== '' &&
+    roomInfo.deadLine.date.trim() !== '' &&
+    roomInfo.deadLine.time.trim() !== '';
+
+  // 추후 어떤 조건이 빠졌는지도 반환하는 함수 만들어도 좋을듯
+
   return {
     title,
     availableDates,
     time,
     deadLine,
     isPublic,
+    isReadyToCreateRoom,
   };
 };
 

--- a/frontend/src/hooks/useCreateRoom.ts
+++ b/frontend/src/hooks/useCreateRoom.ts
@@ -36,7 +36,7 @@ export const useCreateRoom = () => {
 
   const time = {
     value: roomInfo.time,
-    set: (startTime: string, endTime: string) =>
+    set: ({ startTime, endTime }: { startTime: string; endTime: string }) =>
       setRoomInfo((prev) => ({ ...prev, time: { startTime, endTime } })),
   };
 

--- a/frontend/src/hooks/useCreateRoom.ts
+++ b/frontend/src/hooks/useCreateRoom.ts
@@ -5,7 +5,7 @@ interface RoomInfo {
   availableDates: Set<string>;
   time: { startTime: string; endTime: string };
   deadLine: { date: string; time: string };
-  isPublic: boolean;
+  isPublic: 'public' | 'private';
   roomSession?: string;
 }
 
@@ -20,7 +20,7 @@ const initialRoomInfo: RoomInfo = {
     date: '2025-07-23',
     time: '16:00',
   },
-  isPublic: true,
+  isPublic: 'public',
   roomSession: '',
 };
 
@@ -51,7 +51,7 @@ export const useCreateRoom = () => {
 
   const isPublic = {
     value: roomInfo.isPublic,
-    set: (isPublic: boolean) => setRoomInfo((prev) => ({ ...prev, isPublic })),
+    set: (isPublic: 'public' | 'private') => setRoomInfo((prev) => ({ ...prev, isPublic })),
   };
 
   const isReadyToCreateRoom =

--- a/frontend/src/hooks/useCreateRoom.ts
+++ b/frontend/src/hooks/useCreateRoom.ts
@@ -4,7 +4,7 @@ interface RoomInfo {
   title: string;
   availableDates: Set<string>;
   time: { startTime: string; endTime: string };
-  deadLine: string;
+  deadLine: { date: string; time: string };
   isPublic: boolean;
   roomSession?: string;
 }
@@ -16,7 +16,10 @@ const initialRoomInfo: RoomInfo = {
     startTime: '',
     endTime: '',
   },
-  deadLine: '',
+  deadLine: {
+    date: '2025-07-23',
+    time: '16:00',
+  },
   isPublic: true,
   roomSession: '',
 };
@@ -42,7 +45,8 @@ export const useCreateRoom = () => {
 
   const deadline = {
     value: roomInfo.deadLine,
-    set: (deadLine: string) => setRoomInfo((prev) => ({ ...prev, deadLine })),
+    set: ({ date, time }: { date: string; time: string }) =>
+      setRoomInfo((prev) => ({ ...prev, deadLine: { date, time } })),
   };
 
   const isPublic = {

--- a/frontend/src/hooks/useCreateRoom.ts
+++ b/frontend/src/hooks/useCreateRoom.ts
@@ -43,7 +43,7 @@ export const useCreateRoom = () => {
       setRoomInfo((prev) => ({ ...prev, time: { startTime, endTime } })),
   };
 
-  const deadline = {
+  const deadLine = {
     value: roomInfo.deadLine,
     set: ({ date, time }: { date: string; time: string }) =>
       setRoomInfo((prev) => ({ ...prev, deadLine: { date, time } })),
@@ -58,7 +58,7 @@ export const useCreateRoom = () => {
     title,
     availableDates,
     time,
-    deadline,
+    deadLine,
     isPublic,
   };
 };

--- a/frontend/src/hooks/useCreateRoom.ts
+++ b/frontend/src/hooks/useCreateRoom.ts
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+
+interface RoomInfo {
+  title: string;
+  availableDates: Set<string>;
+  time: { startTime: string; endTime: string };
+  deadLine: string;
+  isPublic: boolean;
+  roomSession?: string;
+}
+
+const initialRoomInfo: RoomInfo = {
+  title: '',
+  availableDates: new Set(),
+  time: {
+    startTime: '',
+    endTime: '',
+  },
+  deadLine: '',
+  isPublic: true,
+  roomSession: '',
+};
+
+export const useCreateRoom = () => {
+  const [roomInfo, setRoomInfo] = useState<RoomInfo>(initialRoomInfo);
+
+  const title = {
+    value: roomInfo.title,
+    set: (title: string) => setRoomInfo((prev) => ({ ...prev, title })),
+  };
+
+  const availableDates = {
+    value: roomInfo.availableDates,
+    set: (availableDates: Set<string>) => setRoomInfo((prev) => ({ ...prev, availableDates })),
+  };
+
+  const time = {
+    value: roomInfo.time,
+    set: (startTime: string, endTime: string) =>
+      setRoomInfo((prev) => ({ ...prev, time: { startTime, endTime } })),
+  };
+
+  const deadline = {
+    value: roomInfo.deadLine,
+    set: (deadLine: string) => setRoomInfo((prev) => ({ ...prev, deadLine })),
+  };
+
+  const isPublic = {
+    value: roomInfo.isPublic,
+    set: (isPublic: boolean) => setRoomInfo((prev) => ({ ...prev, isPublic })),
+  };
+
+  return {
+    title,
+    availableDates,
+    time,
+    deadline,
+    isPublic,
+  };
+};
+
+export default useCreateRoom;

--- a/frontend/src/hooks/useCreateRoom.ts
+++ b/frontend/src/hooks/useCreateRoom.ts
@@ -64,6 +64,10 @@ export const useCreateRoom = () => {
 
   // 추후 어떤 조건이 빠졌는지도 반환하는 함수 만들어도 좋을듯
 
+  const roomInfoSubmit = () => {
+    console.log(roomInfo);
+  };
+
   return {
     title,
     availableDates,
@@ -71,6 +75,7 @@ export const useCreateRoom = () => {
     deadLine,
     isPublic,
     isReadyToCreateRoom,
+    roomInfoSubmit,
   };
 };
 

--- a/frontend/src/hooks/useSelectTime.ts
+++ b/frontend/src/hooks/useSelectTime.ts
@@ -1,9 +1,13 @@
 import { TIME } from '@/constants/time';
 import { useCallback, useState } from 'react';
 
-const useSelectTime = () => {
+interface TimeRangeField {
+  timeRange: { startTime: string; endTime: string };
+  setTimeRange: ({ startTime, endTime }: { startTime: string; endTime: string }) => void;
+}
+
+const useSelectTime = ({ timeRange, setTimeRange }: TimeRangeField) => {
   const [selectedButtons, setSelectedButtons] = useState<('day' | 'night' | 'custom')[]>([]);
-  const [timeRange, setTimeRange] = useState({ startTime: '', endTime: '' });
 
   const handleDayNightButtonClick = useCallback(
     (type: 'day' | 'night') => {

--- a/frontend/src/hooks/useTimePicker.ts
+++ b/frontend/src/hooks/useTimePicker.ts
@@ -1,20 +1,13 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 const useTimePicker = () => {
   const [isOpen, setIsOpen] = useState(false);
-  const [selectedHour, setSelectedHour] = useState<string>('');
 
   const toggleOpen = () => {
     setIsOpen((prev) => !prev);
   };
 
-  const selectHour = (hour: string, e: React.MouseEvent) => {
-    e.stopPropagation();
-    setSelectedHour(hour);
-    setIsOpen(false);
-  };
-
-  return { selectedHour, selectHour, toggleOpen, isOpen };
+  return { toggleOpen, isOpen };
 };
 
 export default useTimePicker;

--- a/frontend/src/pages/CreateEventPage.tsx
+++ b/frontend/src/pages/CreateEventPage.tsx
@@ -7,6 +7,7 @@ import CalendarSettings from '@/components/Sections/CalendarSettings';
 import Button from '@/components/Button';
 import Text from '@/components/Text';
 import { useNavigate } from 'react-router';
+import useCreateRoom from '@/hooks/useCreateRoom';
 
 const CreateEventPage = () => {
   const navigate = useNavigate();
@@ -14,6 +15,8 @@ const CreateEventPage = () => {
   const [isOpenAccordion, setIsOpenAccordion] = useState(false);
   const [isDeadlineEnable, setisDeadlineEnable] = useState(false);
   const [date, setDate] = useState('2025-07-19');
+
+  const { title } = useCreateRoom();
 
   return (
     <Wrapper maxWidth={1280} paddingTop="var(--padding-11)" paddingBottom="var(--padding-11)">
@@ -23,7 +26,7 @@ const CreateEventPage = () => {
         </Flex.Item>
         <Flex.Item flex={1}>
           <Flex direction="column" justify="space-between" gap="var(--gap-8)">
-            <BasicSettings />
+            <BasicSettings title={title} />
             <OptionSettings
               isOpenAccordion={isOpenAccordion}
               onToggleAccordion={() => setIsOpenAccordion((prev) => !prev)}

--- a/frontend/src/pages/CreateEventPage.tsx
+++ b/frontend/src/pages/CreateEventPage.tsx
@@ -13,7 +13,6 @@ const CreateEventPage = () => {
   const navigate = useNavigate();
   // 상세 설정 상태
   const [isOpenAccordion, setIsOpenAccordion] = useState(false);
-  const [isDeadlineEnable, setisDeadlineEnable] = useState(false);
   const [date, setDate] = useState('2025-07-19');
 
   const { title, availableDates, time } = useCreateRoom();
@@ -30,8 +29,6 @@ const CreateEventPage = () => {
             <OptionSettings
               isOpenAccordion={isOpenAccordion}
               onToggleAccordion={() => setIsOpenAccordion((prev) => !prev)}
-              isDeadlineEnable={isDeadlineEnable}
-              onToggleDeadline={() => setisDeadlineEnable((prev) => !prev)}
               date={date}
               onDateChange={(e: React.ChangeEvent<HTMLInputElement>) => setDate(e.target.value)}
             />

--- a/frontend/src/pages/CreateEventPage.tsx
+++ b/frontend/src/pages/CreateEventPage.tsx
@@ -10,8 +10,7 @@ import useCreateRoom from '@/hooks/useCreateRoom';
 
 const CreateEventPage = () => {
   const navigate = useNavigate();
-
-  const { title, availableDates, time, deadLine, isPublic } = useCreateRoom();
+  const { title, availableDates, time, deadLine, isPublic, isReadyToCreateRoom } = useCreateRoom();
 
   return (
     <Wrapper maxWidth={1280} paddingTop="var(--padding-11)" paddingBottom="var(--padding-11)">
@@ -25,9 +24,10 @@ const CreateEventPage = () => {
             <OptionSettings deadLine={deadLine} isPublic={isPublic} />
             <Flex justify="flex-end">
               <Button
-                color="primary"
+                color={isReadyToCreateRoom ? 'primary' : 'plum40'}
                 selected={true}
                 size="small"
+                disabled={!isReadyToCreateRoom}
                 onClick={() => navigate(`/check?id=${124124124}`)}
               >
                 <Text variant="button" color="background">

--- a/frontend/src/pages/CreateEventPage.tsx
+++ b/frontend/src/pages/CreateEventPage.tsx
@@ -12,7 +12,6 @@ import useCreateRoom from '@/hooks/useCreateRoom';
 const CreateEventPage = () => {
   const navigate = useNavigate();
   // 상세 설정 상태
-  const [isOpenAccordion, setIsOpenAccordion] = useState(false);
   const [date, setDate] = useState('2025-07-19');
 
   const { title, availableDates, time } = useCreateRoom();
@@ -27,8 +26,6 @@ const CreateEventPage = () => {
           <Flex direction="column" justify="space-between" gap="var(--gap-8)">
             <BasicSettings title={title} time={time} />
             <OptionSettings
-              isOpenAccordion={isOpenAccordion}
-              onToggleAccordion={() => setIsOpenAccordion((prev) => !prev)}
               date={date}
               onDateChange={(e: React.ChangeEvent<HTMLInputElement>) => setDate(e.target.value)}
             />

--- a/frontend/src/pages/CreateEventPage.tsx
+++ b/frontend/src/pages/CreateEventPage.tsx
@@ -16,7 +16,7 @@ const CreateEventPage = () => {
   const [isDeadlineEnable, setisDeadlineEnable] = useState(false);
   const [date, setDate] = useState('2025-07-19');
 
-  const { title, availableDates } = useCreateRoom();
+  const { title, availableDates, time } = useCreateRoom();
 
   return (
     <Wrapper maxWidth={1280} paddingTop="var(--padding-11)" paddingBottom="var(--padding-11)">
@@ -26,7 +26,7 @@ const CreateEventPage = () => {
         </Flex.Item>
         <Flex.Item flex={1}>
           <Flex direction="column" justify="space-between" gap="var(--gap-8)">
-            <BasicSettings title={title} />
+            <BasicSettings title={title} time={time} />
             <OptionSettings
               isOpenAccordion={isOpenAccordion}
               onToggleAccordion={() => setIsOpenAccordion((prev) => !prev)}

--- a/frontend/src/pages/CreateEventPage.tsx
+++ b/frontend/src/pages/CreateEventPage.tsx
@@ -10,7 +10,8 @@ import useCreateRoom from '@/hooks/useCreateRoom';
 
 const CreateEventPage = () => {
   const navigate = useNavigate();
-  const { title, availableDates, time, deadLine, isPublic, isReadyToCreateRoom } = useCreateRoom();
+  const { title, availableDates, time, deadLine, isPublic, isReadyToCreateRoom, roomInfoSubmit } =
+    useCreateRoom();
 
   return (
     <Wrapper maxWidth={1280} paddingTop="var(--padding-11)" paddingBottom="var(--padding-11)">
@@ -28,7 +29,10 @@ const CreateEventPage = () => {
                 selected={true}
                 size="small"
                 disabled={!isReadyToCreateRoom}
-                onClick={() => navigate(`/check?id=${124124124}`)}
+                onClick={() => {
+                  navigate(`/check?id=${124124124}`);
+                  roomInfoSubmit();
+                }}
               >
                 <Text variant="button" color="background">
                   방 만들기

--- a/frontend/src/pages/CreateEventPage.tsx
+++ b/frontend/src/pages/CreateEventPage.tsx
@@ -1,4 +1,3 @@
-import React, { useState } from 'react';
 import Flex from '@/components/Layout/Flex';
 import Wrapper from '@/components/Layout/Wrapper';
 import BasicSettings from '@/components/Sections/BasicSettings';
@@ -11,10 +10,8 @@ import useCreateRoom from '@/hooks/useCreateRoom';
 
 const CreateEventPage = () => {
   const navigate = useNavigate();
-  // 상세 설정 상태
-  const [date, setDate] = useState('2025-07-19');
 
-  const { title, availableDates, time } = useCreateRoom();
+  const { title, availableDates, time, deadLine } = useCreateRoom();
 
   return (
     <Wrapper maxWidth={1280} paddingTop="var(--padding-11)" paddingBottom="var(--padding-11)">
@@ -25,10 +22,7 @@ const CreateEventPage = () => {
         <Flex.Item flex={1}>
           <Flex direction="column" justify="space-between" gap="var(--gap-8)">
             <BasicSettings title={title} time={time} />
-            <OptionSettings
-              date={date}
-              onDateChange={(e: React.ChangeEvent<HTMLInputElement>) => setDate(e.target.value)}
-            />
+            <OptionSettings deadLine={deadLine} />
             <Flex justify="flex-end">
               <Button
                 color="primary"

--- a/frontend/src/pages/CreateEventPage.tsx
+++ b/frontend/src/pages/CreateEventPage.tsx
@@ -11,7 +11,7 @@ import useCreateRoom from '@/hooks/useCreateRoom';
 const CreateEventPage = () => {
   const navigate = useNavigate();
 
-  const { title, availableDates, time, deadLine } = useCreateRoom();
+  const { title, availableDates, time, deadLine, isPublic } = useCreateRoom();
 
   return (
     <Wrapper maxWidth={1280} paddingTop="var(--padding-11)" paddingBottom="var(--padding-11)">
@@ -22,7 +22,7 @@ const CreateEventPage = () => {
         <Flex.Item flex={1}>
           <Flex direction="column" justify="space-between" gap="var(--gap-8)">
             <BasicSettings title={title} time={time} />
-            <OptionSettings deadLine={deadLine} />
+            <OptionSettings deadLine={deadLine} isPublic={isPublic} />
             <Flex justify="flex-end">
               <Button
                 color="primary"

--- a/frontend/src/pages/CreateEventPage.tsx
+++ b/frontend/src/pages/CreateEventPage.tsx
@@ -16,13 +16,13 @@ const CreateEventPage = () => {
   const [isDeadlineEnable, setisDeadlineEnable] = useState(false);
   const [date, setDate] = useState('2025-07-19');
 
-  const { title } = useCreateRoom();
+  const { title, availableDates } = useCreateRoom();
 
   return (
     <Wrapper maxWidth={1280} paddingTop="var(--padding-11)" paddingBottom="var(--padding-11)">
       <Flex justify="space-between" gap="var(--gap-9)">
         <Flex.Item flex={1}>
-          <CalendarSettings />
+          <CalendarSettings availableDates={availableDates} />
         </Flex.Item>
         <Flex.Item flex={1}>
           <Flex direction="column" justify="space-between" gap="var(--gap-8)">

--- a/frontend/src/types/field.ts
+++ b/frontend/src/types/field.ts
@@ -1,0 +1,4 @@
+export type Field<T> = {
+  value: T;
+  set: (value: T) => void;
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #141 

## 📝 작업 내용

- [x] useCreateRoom 훅 생성
- [x] 내부 상태들 (value와 setter)로 접근할 수 있게 묶어서 export
- [x] 기존 컴포넌트 내부 관리 상태 교체
- [x] 데드라인 토글 컴포넌트 제거
- [x] timePicker 선택옵션 시간 설정 공백 제거 (기존: `"09 : 00"` / 변경: `"09:00"`)
- [x] 상태 전체 반영 체크 함수 제작

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
