### PR TITLE
[BUILD FAIL] 프론트엔드 개발 서버의 API 요청을 위한 CORS 허용

### DIFF
--- a/backend/src/main/java/com/bether/bether/common/config/WebConfig.java
+++ b/backend/src/main/java/com/bether/bether/common/config/WebConfig.java
@@ -1,0 +1,23 @@
+package com.bether.bether.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${cors.allowed-origins}")
+    private String[] allowedOrigins;
+
+    @Override
+    public void addCorsMappings(final CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins(allowedOrigins) // TODO: 실제 배포 시 프론트엔드 URL로 변경
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE")
+                .allowedHeaders("*")
+                .allowCredentials(false)
+                .maxAge(7200);
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -19,6 +19,9 @@ spring:
       hibernate:
         format_sql: true
 
+cors:
+  allowed-origins: ${CORS_ALLOWED_ORIGINS}
+
 discord:
   bot:
     token: ${DISCORD_BOT_TOKEN}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #171 

## 📝 작업 내용

프론트엔드 개발 과정에서 프론트엔드 개발 서버(http://localhost:3000) 에서 백엔드 개발 서버(http://{ec2_IP_address})로 API를 호출할 때 발생하는 CORS 오류를 해결합니다.

- 백엔드 서버에 CORS 관련 설정 추가
  - http://localhost:3000 origin 허용
  - GET, POST, PUT, DELETE, PATCH 메서드 허용
  - 환경변수 allowedOrigin 추가 


## 💬 리뷰 요구사항(선택)

(선택) Authorization, Credentials (쿠키 등) 허용 설정
-> 아직 쿠키 사용 로직이 없어 막아두었고, 추후 사용시 `allowCredentials()` 메서드를 true로 변경하여 해결합니다. 
> allowCredentials(false)
