### PR TITLE
RecommendTime(추천시간대) 컴포넌트 구현

### DIFF
--- a/frontend/src/apis/room/room.ts
+++ b/frontend/src/apis/room/room.ts
@@ -1,6 +1,10 @@
 import api from '../common';
 import { ROOM_API_PATH } from '../common/constant';
-import { CreateRoomResponseType, CreateRoomRequestType, GetRoomInfoResponseType } from './type';
+import type {
+  CreateRoomResponseType,
+  CreateRoomRequestType,
+  GetRoomInfoResponseType,
+} from './type';
 
 export const createRoom = async (body: CreateRoomRequestType): Promise<CreateRoomResponseType> => {
   return await api.post(`${ROOM_API_PATH}`, body);

--- a/frontend/src/apis/time/time.ts
+++ b/frontend/src/apis/time/time.ts
@@ -1,6 +1,6 @@
 import api from '../common';
 import { ROOM_API_PATH } from '../common/constant';
-import {
+import type {
   CombinedAvailableTimesResponseType,
   UserAvailableTimeResponseType,
   RecommendationTimeResponseType,

--- a/frontend/src/components/RecommendTime/RecommendTime.tsx
+++ b/frontend/src/components/RecommendTime/RecommendTime.tsx
@@ -1,0 +1,58 @@
+import { getDayOfWeek } from '@/utils/getDayOfWeek';
+import Wrapper from '../Layout/Wrapper';
+import Text from '../Text';
+import Flex from '@/components/Layout/Flex';
+import { useTheme } from '@emotion/react';
+
+const RecommendTime = ({ dateTimes }: { dateTimes: string[] }) => {
+  const parsedDateTimes = dateTimes.map((dateTime) => {
+    const [datePart, timePart] = dateTime.split('T');
+    const [month, day] = datePart.split('-').slice(1);
+    return {
+      month: Number(month),
+      day: Number(day),
+      dayOfWeek: getDayOfWeek(datePart),
+      time: timePart,
+    };
+  });
+
+  const { colors } = useTheme();
+
+  return (
+    <Wrapper
+      maxWidth={404}
+      padding="var(--padding-7)"
+      backgroundColor={colors.gray20}
+      borderRadius="var(--radius-4)"
+    >
+      <Flex direction="column" gap="var(--gap-5)">
+        <Text variant="button">추천 시간대</Text>
+        <Wrapper center={false} maxWidth={'100%'}>
+          <Flex justify="space-around">
+            {parsedDateTimes.map(({ month, day, dayOfWeek, time }, index) => (
+              <Wrapper
+                key={index}
+                backgroundColor={colors.gray10}
+                borderRadius="var(--radius-4)"
+                paddingTop="var(--padding-6)"
+                paddingBottom="var(--padding-6)"
+                paddingLeft="var(--padding-10)"
+                paddingRight="var(--padding-10)"
+              >
+                <Flex direction="column" align="center" gap="var(--gap-3)">
+                  <Text variant="button" color="primary">
+                    {index + 1}순위
+                  </Text>
+                  <Text>{`${month}월 ${day}일 (${dayOfWeek})`}</Text>
+                  <Text>{time}</Text>
+                </Flex>
+              </Wrapper>
+            ))}
+          </Flex>
+        </Wrapper>
+      </Flex>
+    </Wrapper>
+  );
+};
+
+export default RecommendTime;

--- a/frontend/src/components/RecommendTime/index.tsx
+++ b/frontend/src/components/RecommendTime/index.tsx
@@ -27,7 +27,7 @@ const RecommendTime = ({ dateTimes }: { dateTimes: string[] }) => {
     >
       <Flex direction="column" gap="var(--gap-5)">
         <Text variant="button">추천 시간대</Text>
-        <Wrapper center={false} maxWidth={'100%'}>
+        <Wrapper center={false} maxWidth="100%">
           <Flex justify="space-around">
             {parsedDateTimes.map(({ month, day, dayOfWeek, time }, index) => (
               <Wrapper


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #184 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 추천 시간대 UI 구현
- 추천 시간대 스타일 적용

### 스크린샷 (선택)

<img width="1173" height="304" alt="image" src="https://github.com/user-attachments/assets/53be99bb-3603-4dc3-994b-0877ea6b3760" />
<img width="1173" height="292" alt="image" src="https://github.com/user-attachments/assets/969dff86-b291-43de-93d3-353823ce0a6d" />


## 💬 전달 사항
- 일단 배경 색상은 기존에 있는 grayScale 사용해서 작업했습니다.
- 만약 theme.ts에 지금 피그마에 있는 추천 시간대 배경 색을 새로 추가한다고 하면 새로운 변수 네이밍으로 2개의 색상 추가하고 그에 대응하는 다크모드 색상을 2개 만들면 어떨까요? 지금 있는 graysalce에 추가하면 짝이 안맞아서 변동이 좀 클 것 같아서요..! 
- 그리고 추가로 import 앞에 type 붙이는 작업 작은 부분이라 이 컴포넌트 PR에 같이 올렸습니다..!