### PR TITLE
TimePicker 옵션 선택 제한 기능 추가 

### DIFF
--- a/frontend/src/apis/transform/toCreateRoomInfo.ts
+++ b/frontend/src/apis/transform/toCreateRoomInfo.ts
@@ -1,5 +1,6 @@
 import { RoomInfo } from '@/types/roomInfo';
 import { CreateRoomRequestType } from '../room/type';
+import { subtract30Minutes } from '@/utils/Time/subtract30Minutes';
 
 /**
  * 클라이언트 상태(RoomInfo)를 서버 요청 형식(CreateRoomRequestType)으로 변환합니다.
@@ -13,9 +14,9 @@ export const toCreateRoomInfo = (roomInfo: RoomInfo): CreateRoomRequestType => {
   return {
     title,
     availableDates: Array.from(availableDates),
-    startTime: time.startTime,
-    endTime: time.endTime,
-    deadLine: `${deadLine.date}T${deadLine.time}:00`,
+    startTime: subtract30Minutes(time.startTime),
+    endTime: subtract30Minutes(time.endTime),
+    deadLine: `${deadLine.date}T${subtract30Minutes(deadLine.time)}`,
     isPublic: isPublic === 'public',
   };
 };

--- a/frontend/src/components/DatePicker/index.tsx
+++ b/frontend/src/components/DatePicker/index.tsx
@@ -13,6 +13,7 @@ const DatePicker = ({ isError = false, ...props }: DatePickerProps) => {
       type="date"
       value={date}
       onClick={(e) => e.currentTarget.showPicker()}
+      min={new Date().toISOString().split('T')[0]}
       isError={isError}
       {...props}
     />

--- a/frontend/src/components/Sections/BasicSettings/index.tsx
+++ b/frontend/src/components/Sections/BasicSettings/index.tsx
@@ -9,6 +9,7 @@ import ISun from '@/icons/ISun';
 import IMoon from '@/icons/IMoon';
 import { Field } from '@/types/field';
 import useChangeIconColor from '@/hooks/common/useChangeIconColor';
+import { DEFAULT_HOUR_OPTIONS } from '@/constants/defaultHourOptions';
 
 type BasicSettingsProps = {
   title: Field<string>;
@@ -23,6 +24,7 @@ const BasicSettings = ({ title, time }: BasicSettingsProps) => {
   const {
     timeRange,
     selectedButtons,
+    endHourOptions,
     handleDayNightButtonClick,
     handleCustomButtonClick,
     handleCustomStartClick,
@@ -111,6 +113,7 @@ const BasicSettings = ({ title, time }: BasicSettingsProps) => {
                   selectHour={handleCustomStartClick}
                   toggleOpen={toggleStartOpen}
                   isOpen={isStartOpen}
+                  hourOptions={DEFAULT_HOUR_OPTIONS}
                 />
               </S.Label>
               <S.Label>
@@ -120,6 +123,7 @@ const BasicSettings = ({ title, time }: BasicSettingsProps) => {
                   selectHour={handleCustomEndClick}
                   toggleOpen={toggleEndOpen}
                   isOpen={isEndOpen}
+                  hourOptions={endHourOptions}
                 />
               </S.Label>
             </S.CustomTimeWrapper>

--- a/frontend/src/components/Sections/OptionSettings/index.tsx
+++ b/frontend/src/components/Sections/OptionSettings/index.tsx
@@ -7,8 +7,10 @@ import TimePicker from '@/components/Timepicker';
 import { useTheme } from '@emotion/react';
 import { ACCESS_OPTIONS } from '@/constants/optionsettings';
 import useTimePicker from '@/hooks/useTimePicker';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Field } from '@/types/field';
+import { filterHourOptions } from '@/utils/Time/filterHourOptions';
+import { DEFAULT_HOUR_OPTIONS } from '@/constants/defaultHourOptions';
 
 interface OptionSettingsProps {
   deadLine: Field<{ date: string; time: string }>;
@@ -31,6 +33,12 @@ const OptionSettings = ({ deadLine, isPublic }: OptionSettingsProps) => {
   const { toggleOpen, isOpen } = useTimePicker();
   const [isOpenAccordion, setIsOpenAccordion] = useState(false);
 
+  const deadLineHourOptions = useMemo(() => {
+    return deadLine.value.date === new Date().toISOString().slice(0, 10)
+      ? filterHourOptions(deadLine.value.time)
+      : DEFAULT_HOUR_OPTIONS;
+  }, [deadLine.value.date]);
+
   return (
     <S.Container>
       <Accordion
@@ -52,6 +60,7 @@ const OptionSettings = ({ deadLine, isPublic }: OptionSettingsProps) => {
               selectHour={(hour: string) => deadLine.set({ date: deadLine.value.date, time: hour })}
               toggleOpen={toggleOpen}
               isOpen={isOpen}
+              hourOptions={deadLineHourOptions}
             />
           </S.Wrapper>
         </S.Wrapper>

--- a/frontend/src/components/Timepicker/index.tsx
+++ b/frontend/src/components/Timepicker/index.tsx
@@ -4,19 +4,21 @@ import Text from '../Text';
 import IClock from '@/icons/IClock';
 import { useTheme } from '@emotion/react';
 
-const hourOptions = Array.from({ length: 24 }, (_, i) => {
-  const hour = `${String(i).padStart(2, '0')} : 00`;
-  return hour;
-});
-
 interface TimePickerProps extends ComponentProps<'input'> {
   selectedHour: string | null;
   selectHour: (hour: string, e: React.MouseEvent<HTMLLIElement>) => void;
   toggleOpen: () => void;
   isOpen: boolean;
+  hourOptions: string[];
 }
 
-const TimePicker = ({ selectedHour, selectHour, toggleOpen, isOpen }: TimePickerProps) => {
+const TimePicker = ({
+  selectedHour,
+  selectHour,
+  toggleOpen,
+  isOpen,
+  hourOptions,
+}: TimePickerProps) => {
   const { colors } = useTheme();
 
   return (

--- a/frontend/src/constants/defaultHourOptions.ts
+++ b/frontend/src/constants/defaultHourOptions.ts
@@ -1,0 +1,4 @@
+export const DEFAULT_HOUR_OPTIONS = Array.from({ length: 25 }, (_, i) => {
+  const hour = `${String(i).padStart(2, '0')} : 00`;
+  return hour;
+});

--- a/frontend/src/hooks/useSelectTime.ts
+++ b/frontend/src/hooks/useSelectTime.ts
@@ -1,5 +1,6 @@
 import { TIME } from '@/constants/time';
-import { useCallback, useState } from 'react';
+import { filterHourOptions } from '@/utils/Time/filterHourOptions';
+import { useCallback, useMemo, useState } from 'react';
 interface TimeRangeField {
   timeRange: { startTime: string; endTime: string };
   setTimeRange: ({ startTime, endTime }: { startTime: string; endTime: string }) => void;
@@ -7,6 +8,10 @@ interface TimeRangeField {
 
 const useSelectTime = ({ timeRange, setTimeRange }: TimeRangeField) => {
   const [selectedButtons, setSelectedButtons] = useState<('day' | 'night' | 'custom')[]>([]);
+
+  const endHourOptions = useMemo(() => {
+    return filterHourOptions(timeRange.startTime);
+  }, [timeRange.startTime]);
 
   const handleDayNightButtonClick = useCallback(
     (type: 'day' | 'night') => {
@@ -47,6 +52,7 @@ const useSelectTime = ({ timeRange, setTimeRange }: TimeRangeField) => {
   return {
     timeRange,
     selectedButtons,
+    endHourOptions,
     handleDayNightButtonClick,
     handleCustomButtonClick,
     handleCustomStartClick,

--- a/frontend/src/utils/Time/filterHourOptions.ts
+++ b/frontend/src/utils/Time/filterHourOptions.ts
@@ -1,0 +1,9 @@
+import { DEFAULT_HOUR_OPTIONS } from '@/constants/defaultHourOptions';
+
+export const filterHourOptions = (time: string) => {
+  return DEFAULT_HOUR_OPTIONS.filter((option) => {
+    const hourPart = Number(time.split(':')[0]);
+    const defaultHourPart = Number(option.split(':')[0]);
+    return hourPart < defaultHourPart;
+  });
+};

--- a/frontend/src/utils/Time/subtract30Minutes.ts
+++ b/frontend/src/utils/Time/subtract30Minutes.ts
@@ -1,0 +1,12 @@
+export function subtract30Minutes(timeStr: string): string {
+  const [hours, minutes] = timeStr.split(':').map(Number);
+
+  let totalMinutes = hours * 60 + minutes - 30;
+
+  if (totalMinutes < 0) totalMinutes += 24 * 60;
+
+  const newHours = String(Math.floor(totalMinutes / 60)).padStart(2, '0');
+  const newMinutes = String(totalMinutes % 60).padStart(2, '0');
+
+  return `${newHours}:${newMinutes}`;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #199 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [x] DatePicker 이전 날짜 선택 불가능하도록 설정 추가
- [x] TimePicker 내부에 hourOptions prop 추가
- [x] 마감 시간과 옵션 선택 시간 제한 로직 추가
- [x] 현재 시간에서 30분 빼는 유틸 함수 추가 및 createRoomInfo에 적용

### 스크린샷 (선택)

<img width="876" height="502" alt="image" src="https://github.com/user-attachments/assets/aa799cae-1c69-4141-8577-4968ff2c816b" />
<img width="957" height="392" alt="image" src="https://github.com/user-attachments/assets/f862e78f-36fa-48ad-b7cb-2c0e0b34bbf8" />

## 💬 리뷰 요구사항(선택)
