### PR TITLE
사용자 제출 시간 수정 API response 수정

### DIFF
--- a/backend/src/main/java/com/bether/bether/datetimeslot/application/service/DateTimeSlotService.java
+++ b/backend/src/main/java/com/bether/bether/datetimeslot/application/service/DateTimeSlotService.java
@@ -48,13 +48,14 @@ public class DateTimeSlotService {
     }
 
     @Transactional
-    public void updateTimeSlots(final Long roomId, final DateTimeSlotUpdateInput input) {
+    public DateTimeSlots updateTimeSlots(final Long roomId, final DateTimeSlotUpdateInput input) {
         final DateTimeSlots existing = dateTimeSlotRepository.findAllByRoomIdAndUserName(roomId, input.userName());
         final Set<LocalDateTime> existingStartAts = existing.calculateUniqueStartAts();
         final Set<LocalDateTime> requestedStartAts = Set.copyOf(input.dateTimes());
 
+        // TODO DB 조회 로직 최적화 필요
         if (existingStartAts.equals(requestedStartAts)) {
-            return;
+            return getAllByRoomIdAndUserName(roomId, input.userName());
         }
 
         final DateTimeSlots dateTimeSlotsToSave = existing.findSlotsToSave(requestedStartAts, roomId, input.userName());
@@ -66,5 +67,7 @@ public class DateTimeSlotService {
         if (dateTimeSlotsToDelete.isNotEmpty()) {
             dateTimeSlotRepository.deleteAllInBatch(dateTimeSlotsToDelete);
         }
+
+        return getAllByRoomIdAndUserName(roomId, input.userName());
     }
 }

--- a/backend/src/main/java/com/bether/bether/room/application/service/RoomApplicationService.java
+++ b/backend/src/main/java/com/bether/bether/room/application/service/RoomApplicationService.java
@@ -70,9 +70,9 @@ public class RoomApplicationService {
     }
 
     @Transactional
-    public void updateTimeSlots(final DateTimeSlotUpdateInput input) {
+    public DateTimeSlots updateTimeSlots(final DateTimeSlotUpdateInput input) {
         final Long roomId = roomDomainService.getIdBySession(input.roomSession());
-        dateTimeSlotService.updateTimeSlots(roomId, input);
+        return dateTimeSlotService.updateTimeSlots(roomId, input);
     }
 
     @Transactional

--- a/backend/src/main/java/com/bether/bether/room/presentation/RoomController.java
+++ b/backend/src/main/java/com/bether/bether/room/presentation/RoomController.java
@@ -15,6 +15,7 @@ import com.bether.bether.room.presentation.dto.response.RoomCreateResponse;
 import com.bether.bether.room.presentation.dto.response.RoomResponse;
 import com.bether.bether.room.presentation.dto.response.TimeSlotRecommendationsResponse;
 import com.bether.bether.room.presentation.dto.response.TimeSlotStatisticResponse;
+import com.bether.bether.room.presentation.dto.response.TotalDateTimeSlotUpdateResponse;
 import com.bether.bether.room.presentation.dto.response.TotalTimeSlotResponse;
 import com.bether.bether.room.presentation.dto.response.UserCreateResponse;
 import com.bether.bether.user.application.dto.output.UserCreateOutput;
@@ -76,10 +77,11 @@ public class RoomController implements RoomControllerSpecification {
     }
 
     @Override
-    public CustomApiResponse<Void> updateTimeSlots(@PathVariable("session") final UUID session,
-                                                   @RequestBody final TimeSlotUpdateRequest request) {
-        roomApplicationService.updateTimeSlots(request.toInput(session));
-        return CustomApiResponse.ok();
+    public CustomApiResponse<TotalDateTimeSlotUpdateResponse> updateTimeSlots(
+            @PathVariable("session") final UUID session,
+            @RequestBody final TimeSlotUpdateRequest request) {
+        final DateTimeSlots dateTimeSlots = roomApplicationService.updateTimeSlots(request.toInput(session));
+        return CustomApiResponse.ok(TotalDateTimeSlotUpdateResponse.from(dateTimeSlots));
     }
 
     @Override

--- a/backend/src/main/java/com/bether/bether/room/presentation/RoomControllerSpecification.java
+++ b/backend/src/main/java/com/bether/bether/room/presentation/RoomControllerSpecification.java
@@ -9,6 +9,7 @@ import com.bether.bether.room.presentation.dto.response.RoomCreateResponse;
 import com.bether.bether.room.presentation.dto.response.RoomResponse;
 import com.bether.bether.room.presentation.dto.response.TimeSlotRecommendationsResponse;
 import com.bether.bether.room.presentation.dto.response.TimeSlotStatisticResponse;
+import com.bether.bether.room.presentation.dto.response.TotalDateTimeSlotUpdateResponse;
 import com.bether.bether.room.presentation.dto.response.TotalTimeSlotResponse;
 import com.bether.bether.room.presentation.dto.response.UserCreateResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -201,26 +202,34 @@ public interface RoomControllerSpecification {
                                         "code": 200,
                                         "success": true,
                                         "message": null,
-                                        "result": null
+                                        "result": {
+                                                   "message": "저장이 완료되었습니다!",
+                                                   "userName": "강감찬",
+                                                   "dateTimes": [
+                                                       "2025-07-21T16:00",
+                                                       "2025-07-21T17:00",
+                                                       "2025-07-22T20:00"
+                                                   ]
+                                               }
                                     }
                                     """)))})
     @PutMapping("/{session}/time-slots")
-    CustomApiResponse<Void> updateTimeSlots(@PathVariable("session") final UUID session,
-                                            @RequestBody(description = "수정할 사용자의 이름과 새로운 시간 목록을 입력합니다.", required = true, content = @Content(
-                                                    examples = @ExampleObject(
-                                                            summary = "시간 수정 예시",
-                                                            value = """
-                                                                    {
-                                                                        "userName": "강감찬",
-                                                                        "dateTimes": [
-                                                                            "2025-07-21T16:00",
-                                                                            "2025-07-21T17:00",
-                                                                            "2025-07-22T20:00"
-                                                                        ]
-                                                                    }
-                                                                    """
-                                                    )
-                                            )) TimeSlotUpdateRequest request);
+    CustomApiResponse<TotalDateTimeSlotUpdateResponse> updateTimeSlots(@PathVariable("session") final UUID session,
+                                                                       @RequestBody(description = "수정할 사용자의 이름과 새로운 시간 목록을 입력합니다.", required = true, content = @Content(
+                                                                               examples = @ExampleObject(
+                                                                                       summary = "시간 수정 예시",
+                                                                                       value = """
+                                                                                               {
+                                                                                                   "userName": "강감찬",
+                                                                                                   "dateTimes": [
+                                                                                                       "2025-07-21T16:00",
+                                                                                                       "2025-07-21T17:00",
+                                                                                                       "2025-07-22T20:00"
+                                                                                                   ]
+                                                                                               }
+                                                                                               """
+                                                                               )
+                                                                       )) TimeSlotUpdateRequest request);
 
 
     @Operation(summary = "룸 사용자 로그인", description = "💡 특정 룸에 새로운 사용자를 생성(로그인)합니다. 사용자는 이름과 비밀번호로 식별됩니다.")

--- a/backend/src/main/java/com/bether/bether/room/presentation/dto/response/TotalDateTimeSlotUpdateResponse.java
+++ b/backend/src/main/java/com/bether/bether/room/presentation/dto/response/TotalDateTimeSlotUpdateResponse.java
@@ -1,0 +1,28 @@
+package com.bether.bether.room.presentation.dto.response;
+
+import com.bether.bether.datetimeslot.domain.DateTimeSlots;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record TotalDateTimeSlotUpdateResponse(
+        String message,
+        List<TimeSlotUpdateResponse> timeSlots
+) {
+
+    public static TotalDateTimeSlotUpdateResponse from(final DateTimeSlots dateTimeSlots) {
+        return new TotalDateTimeSlotUpdateResponse("저장이 완료되었습니다!",
+                dateTimeSlots.getDateTimeSlots().stream()
+                        .map(timeSlot -> new TimeSlotUpdateResponse(timeSlot.getUserName(), timeSlot.getStartAt()))
+                        .toList()
+        );
+    }
+
+    private record TimeSlotUpdateResponse(
+            String userName,
+
+            @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm")
+            LocalDateTime dateTime
+    ) {
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #231 

## 📝 작업 내용

사용자 제출 시간 수정 API의 response를 수정하였습니다. 특히, data 부분의 값을 null이 아닌 정해진 데이터를 리턴하도록 변경하였습니다.

### 스크린샷 (선택)
<img width="2007" height="1172" alt="스크린샷 2025-07-25 103203" src="https://github.com/user-attachments/assets/ee8d6f02-9f74-4346-828f-38a9c7062873" />


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

급하게 구현하다보니 구조가 만족스럽지 않아 아쉽습니다...
추후에 리팩터링 과정을 진행할 때 수정하는 방향으로 진행하면 될 것 같습니다!
