### PR TITLE
Discord & Slack 알림 링크 접속 오류 수정 및 SlackMessageSender 빈 등록 문제 해결

### DIFF
--- a/backend/src/main/java/com/bether/bether/connection/application/ConnectedRoomApplicationService.java
+++ b/backend/src/main/java/com/bether/bether/connection/application/ConnectedRoomApplicationService.java
@@ -43,7 +43,7 @@ public class ConnectedRoomApplicationService {
      */
     private void sendConnectedRoomCreatedMessage(final ConnectedRoom connectRoom, final String channelId) {
         final Room room = connectRoom.getRoom();
-        final String shortcut = webConfigProperties.dev() + room.getSession();
+        final String shortcut = webConfigProperties.dev() + "/check?id=" + room.getSession();
         final ConnectedRoomCreatedMessageInput input = ConnectedRoomCreatedMessageInput.of(shortcut, room);
         messageSenders.get(connectRoom.getPlatform()).sendConnectedRoomCreatedMessage(channelId, input);
     }

--- a/backend/src/main/java/com/bether/bether/connection/application/dto/input/ConnectedRoomCreatedMessageInput.java
+++ b/backend/src/main/java/com/bether/bether/connection/application/dto/input/ConnectedRoomCreatedMessageInput.java
@@ -10,8 +10,8 @@ public record ConnectedRoomCreatedMessageInput(
 ) {
 
     public static ConnectedRoomCreatedMessageInput of(
-            String shortcut,
-            Room room
+            final String shortcut,
+            final Room room
     ) {
         return new ConnectedRoomCreatedMessageInput(shortcut, room.getTitle(), room.getDeadLine());
     }

--- a/backend/src/main/java/com/bether/bether/connection/slack/application/util/SlackMessageBuilder.java
+++ b/backend/src/main/java/com/bether/bether/connection/slack/application/util/SlackMessageBuilder.java
@@ -59,13 +59,13 @@ public class SlackMessageBuilder {
         );
     }
 
-    private MarkdownTextObject markdown(String text) {
+    private MarkdownTextObject markdown(final String text) {
         return MarkdownTextObject.builder()
                 .text(text)
                 .build();
     }
 
-    private PlainTextObject plainText(String text) {
+    private PlainTextObject plainText(final String text) {
         return PlainTextObject.builder()
                 .text(text)
                 .emoji(true)

--- a/backend/src/main/java/com/bether/bether/connection/slack/infrastructure/SlackMessageSender.java
+++ b/backend/src/main/java/com/bether/bether/connection/slack/infrastructure/SlackMessageSender.java
@@ -79,9 +79,9 @@ public class SlackMessageSender implements MessageSender {
             } else {
                 log.warn("{} failed: {}", failLogPrefix, response.getError());
             }
-        } catch (SlackApiException e) {
+        } catch (final SlackApiException e) {
             log.error("Slack API exception during {}: {}", failLogPrefix, e.getError(), e);
-        } catch (IOException e) {
+        } catch (final IOException e) {
             log.error("I/O error during {}: {}", failLogPrefix, e.getMessage(), e);
         }
     }
@@ -98,9 +98,9 @@ public class SlackMessageSender implements MessageSender {
             } else {
                 log.warn("{} failed: {}", failLogPrefix, response.getError());
             }
-        } catch (SlackApiException e) {
+        } catch (final SlackApiException e) {
             log.error("Slack API exception during {}: {}", failLogPrefix, e.getError(), e);
-        } catch (IOException e) {
+        } catch (final IOException e) {
             log.error("I/O error during {}: {}", failLogPrefix, e.getMessage(), e);
         }
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #239 

## 📝 작업 내용

Discord & Slack 알림에서 제공하는 "시간 입력 알림"의 url 불일치를 수정합니다.

또, MessageSenderConfig의 messageSenderMap에 Slack이 등록되지 않은 것을 수정했습니다.