### PR TITLE
Room session 정렬가능 13자 문자열(TSID) 로 변경

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -39,6 +39,8 @@ dependencies {
     implementation 'org.json:json:20240303' // for JSONObject
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
+
+    implementation 'com.github.f4b6a3:tsid-creator:5.2.6' // for TSID generation
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/bether/bether/connection/application/dto/output/ConnectedRoomCreateOutput.java
+++ b/backend/src/main/java/com/bether/bether/connection/application/dto/output/ConnectedRoomCreateOutput.java
@@ -2,10 +2,9 @@ package com.bether.bether.connection.application.dto.output;
 
 import com.bether.bether.connection.domain.ConnectedRoom;
 import com.bether.bether.connection.domain.Platform;
-import java.util.UUID;
 
 public record ConnectedRoomCreateOutput(
-        UUID session,
+        String session,
         Platform platform
 ) {
 

--- a/backend/src/main/java/com/bether/bether/connection/domain/ConnectedRoomRepository.java
+++ b/backend/src/main/java/com/bether/bether/connection/domain/ConnectedRoomRepository.java
@@ -1,11 +1,10 @@
 package com.bether.bether.connection.domain;
 
 import java.util.Optional;
-import java.util.UUID;
 
 public interface ConnectedRoomRepository {
 
     ConnectedRoom save(ConnectedRoom connectedRoom);
 
-    Optional<ConnectedRoom> findBySession(UUID sessionId);
+    Optional<ConnectedRoom> findBySession(String sessionId);
 }

--- a/backend/src/main/java/com/bether/bether/connection/infrastructure/ConnectedRoomJpaRepository.java
+++ b/backend/src/main/java/com/bether/bether/connection/infrastructure/ConnectedRoomJpaRepository.java
@@ -2,9 +2,8 @@ package com.bether.bether.connection.infrastructure;
 
 import com.bether.bether.connection.domain.ConnectedRoom;
 import java.util.Optional;
-import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ConnectedRoomJpaRepository extends JpaRepository<ConnectedRoom, Long> {
-    Optional<ConnectedRoom> findByRoomSession(UUID sessionId);
+    Optional<ConnectedRoom> findByRoomSession(String sessionId);
 }

--- a/backend/src/main/java/com/bether/bether/connection/infrastructure/ConnectedRoomRepositoryImpl.java
+++ b/backend/src/main/java/com/bether/bether/connection/infrastructure/ConnectedRoomRepositoryImpl.java
@@ -3,7 +3,6 @@ package com.bether.bether.connection.infrastructure;
 import com.bether.bether.connection.domain.ConnectedRoom;
 import com.bether.bether.connection.domain.ConnectedRoomRepository;
 import java.util.Optional;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -19,7 +18,7 @@ public class ConnectedRoomRepositoryImpl implements ConnectedRoomRepository {
     }
 
     @Override
-    public Optional<ConnectedRoom> findBySession(final UUID session) {
+    public Optional<ConnectedRoom> findBySession(final String session) {
         return jpaRepository.findByRoomSession(session);
     }
 }

--- a/backend/src/main/java/com/bether/bether/connection/presentation/ConnectedRoomControllerSpecification.java
+++ b/backend/src/main/java/com/bether/bether/connection/presentation/ConnectedRoomControllerSpecification.java
@@ -28,7 +28,7 @@ public interface ConnectedRoomControllerSpecification {
                                                 "success": true,
                                                 "message": null,
                                                 "result": {
-                                                    "session": "a4b1c2d3-e4f5-6789-0123-456789abcdef",
+                                                    "session": "0MERYHCK3MCYH",
                                                     "platform": "DISCORD"
                                                 }
                                             }

--- a/backend/src/main/java/com/bether/bether/connection/presentation/dto/response/ConnectedRoomCreateResponse.java
+++ b/backend/src/main/java/com/bether/bether/connection/presentation/dto/response/ConnectedRoomCreateResponse.java
@@ -2,10 +2,9 @@ package com.bether.bether.connection.presentation.dto.response;
 
 import com.bether.bether.connection.application.dto.output.ConnectedRoomCreateOutput;
 import com.bether.bether.connection.domain.Platform;
-import java.util.UUID;
 
 public record ConnectedRoomCreateResponse(
-        UUID session,
+        String session,
         Platform platform
 ) {
 

--- a/backend/src/main/java/com/bether/bether/datetimeslot/application/dto/input/DateTimeSlotInput.java
+++ b/backend/src/main/java/com/bether/bether/datetimeslot/application/dto/input/DateTimeSlotInput.java
@@ -4,10 +4,9 @@ import com.bether.bether.datetimeslot.domain.DateTimeSlot;
 import com.bether.bether.datetimeslot.domain.DateTimeSlots;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.UUID;
 
 public record DateTimeSlotInput(
-        UUID roomSession,
+        String roomSession,
         String userName,
         List<LocalDateTime> dateTimes
 ) {

--- a/backend/src/main/java/com/bether/bether/datetimeslot/application/dto/input/DateTimeSlotUpdateInput.java
+++ b/backend/src/main/java/com/bether/bether/datetimeslot/application/dto/input/DateTimeSlotUpdateInput.java
@@ -2,10 +2,9 @@ package com.bether.bether.datetimeslot.application.dto.input;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.UUID;
 
 public record DateTimeSlotUpdateInput(
-        UUID roomSession,
+        String roomSession,
         String userName,
         List<LocalDateTime> dateTimes
 ) {

--- a/backend/src/main/java/com/bether/bether/room/application/dto/RoomCreateOutput.java
+++ b/backend/src/main/java/com/bether/bether/room/application/dto/RoomCreateOutput.java
@@ -1,10 +1,9 @@
 package com.bether.bether.room.application.dto;
 
 import com.bether.bether.room.domain.Room;
-import java.util.UUID;
 
 public record RoomCreateOutput(
-        UUID session
+        String session
 ) {
 
     public static RoomCreateOutput from(final Room room) {

--- a/backend/src/main/java/com/bether/bether/room/application/dto/RoomOutput.java
+++ b/backend/src/main/java/com/bether/bether/room/application/dto/RoomOutput.java
@@ -5,7 +5,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
-import java.util.UUID;
 
 public record RoomOutput(
         String title,
@@ -14,7 +13,7 @@ public record RoomOutput(
         LocalTime endTime,
         LocalDateTime deadLine,
         boolean isPublic,
-        UUID roomSession
+        String roomSession
 ) {
 
     public static RoomOutput from(final Room room) {

--- a/backend/src/main/java/com/bether/bether/room/application/service/RoomApplicationService.java
+++ b/backend/src/main/java/com/bether/bether/room/application/service/RoomApplicationService.java
@@ -13,7 +13,6 @@ import com.bether.bether.room.domain.Room;
 import com.bether.bether.user.application.dto.input.UserCreateInput;
 import com.bether.bether.user.application.dto.output.UserCreateOutput;
 import com.bether.bether.user.application.service.UserDomainService;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,7 +26,7 @@ public class RoomApplicationService {
     private final UserDomainService userDomainService;
 
     @Transactional(readOnly = true)
-    public RoomOutput getBySession(final UUID session) {
+    public RoomOutput getBySession(final String session) {
         final Room room = roomDomainService.getBySession(session);
         return RoomOutput.from(room);
     }
@@ -40,13 +39,13 @@ public class RoomApplicationService {
     }
 
     @Transactional(readOnly = true)
-    public DateTimeSlots getTimeSlotsBySession(final UUID session) {
+    public DateTimeSlots getTimeSlotsBySession(final String session) {
         final Long id = roomDomainService.getIdBySession(session);
         return dateTimeSlotService.getAllByRoomId(id);
     }
 
     @Transactional(readOnly = true)
-    public DateTimeSlots getTimeSlotsBySessionAndUserName(final UUID session, final String userName) {
+    public DateTimeSlots getTimeSlotsBySessionAndUserName(final String session, final String userName) {
         final Long id = roomDomainService.getIdBySession(session);
         return dateTimeSlotService.getAllByRoomIdAndUserName(id, userName);
     }
@@ -58,13 +57,13 @@ public class RoomApplicationService {
     }
 
     @Transactional(readOnly = true)
-    public DateTimeSlotStatisticOutput generateTimeSlotStatistic(final UUID session) {
+    public DateTimeSlotStatisticOutput generateTimeSlotStatistic(final String session) {
         final Long id = roomDomainService.getIdBySession(session);
         return dateTimeSlotService.generateTimeSlotStatistic(id);
     }
 
     @Transactional(readOnly = true)
-    public DateTimeSlotRecommendationsOutput recommendTopTimeSlots(final UUID session) {
+    public DateTimeSlotRecommendationsOutput recommendTopTimeSlots(final String session) {
         final Long id = roomDomainService.getIdBySession(session);
         return dateTimeSlotService.recommendTopTimeSlots(id);
     }
@@ -76,7 +75,7 @@ public class RoomApplicationService {
     }
 
     @Transactional
-    public UserCreateOutput saveUser(final UUID session, final UserCreateInput input) {
+    public UserCreateOutput saveUser(final String session, final UserCreateInput input) {
         final Long id = roomDomainService.getIdBySession(session);
         return UserCreateOutput.from(userDomainService.getByRoomIdAndName(id, input));
     }

--- a/backend/src/main/java/com/bether/bether/room/application/service/RoomDomainService.java
+++ b/backend/src/main/java/com/bether/bether/room/application/service/RoomDomainService.java
@@ -3,7 +3,6 @@ package com.bether.bether.room.application.service;
 import com.bether.bether.common.NotFoundException;
 import com.bether.bether.room.domain.Room;
 import com.bether.bether.room.domain.RoomRepository;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,13 +14,13 @@ public class RoomDomainService {
     private final RoomRepository roomRepository;
 
     @Transactional(readOnly = true)
-    public Room getBySession(final UUID session) {
+    public Room getBySession(final String session) {
         return roomRepository.findBySession(session)
                 .orElseThrow(() -> new NotFoundException(Room.class.getSimpleName()));
     }
 
     @Transactional(readOnly = true)
-    public Long getIdBySession(final UUID session) {
+    public Long getIdBySession(final String session) {
         return getBySession(session).getId(); // TODO 검색 대상 파라미터 명시 여부 논의 필요
     }
 

--- a/backend/src/main/java/com/bether/bether/room/domain/Room.java
+++ b/backend/src/main/java/com/bether/bether/room/domain/Room.java
@@ -2,6 +2,7 @@ package com.bether.bether.room.domain;
 
 import com.bether.bether.common.BaseEntity;
 import com.bether.bether.datetimeslot.domain.DateTimeSlot;
+import com.bether.bether.room.infrastructure.RoomSessionGenerator;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
@@ -13,7 +14,6 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -28,7 +28,7 @@ import lombok.ToString;
 public class Room extends BaseEntity {
 
     @Column(name = "session", nullable = false)
-    private UUID session;
+    private String session;
 
     @Column(name = "title", nullable = false)
     private String title;
@@ -64,7 +64,7 @@ public class Room extends BaseEntity {
         validateDates(availableDates);
         validateTimes(startTime, endTime);
         validateDeadLine(deadLine);
-        final UUID session = UUID.randomUUID();
+        final String session = RoomSessionGenerator.generateTsid();
         return new Room(session, title, availableDates, startTime, endTime, deadLine, isPublic);
     }
 

--- a/backend/src/main/java/com/bether/bether/room/domain/RoomRepository.java
+++ b/backend/src/main/java/com/bether/bether/room/domain/RoomRepository.java
@@ -1,11 +1,10 @@
 package com.bether.bether.room.domain;
 
 import java.util.Optional;
-import java.util.UUID;
 
 public interface RoomRepository {
 
     Room save(Room room);
 
-    Optional<Room> findBySession(UUID session);
+    Optional<Room> findBySession(String session);
 }

--- a/backend/src/main/java/com/bether/bether/room/infrastructure/RoomJpaRepository.java
+++ b/backend/src/main/java/com/bether/bether/room/infrastructure/RoomJpaRepository.java
@@ -2,10 +2,9 @@ package com.bether.bether.room.infrastructure;
 
 import com.bether.bether.room.domain.Room;
 import java.util.Optional;
-import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RoomJpaRepository extends JpaRepository<Room, Long> {
 
-    Optional<Room> findBySession(UUID session);
+    Optional<Room> findBySession(String session);
 }

--- a/backend/src/main/java/com/bether/bether/room/infrastructure/RoomRepositoryImpl.java
+++ b/backend/src/main/java/com/bether/bether/room/infrastructure/RoomRepositoryImpl.java
@@ -3,7 +3,6 @@ package com.bether.bether.room.infrastructure;
 import com.bether.bether.room.domain.Room;
 import com.bether.bether.room.domain.RoomRepository;
 import java.util.Optional;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -19,7 +18,7 @@ public class RoomRepositoryImpl implements RoomRepository {
     }
 
     @Override
-    public Optional<Room> findBySession(final UUID session) {
+    public Optional<Room> findBySession(final String session) {
         return roomJpaRepository.findBySession(session);
     }
 }

--- a/backend/src/main/java/com/bether/bether/room/infrastructure/RoomSessionGenerator.java
+++ b/backend/src/main/java/com/bether/bether/room/infrastructure/RoomSessionGenerator.java
@@ -1,0 +1,10 @@
+package com.bether.bether.room.infrastructure;
+
+import com.github.f4b6a3.tsid.TsidCreator;
+
+public class RoomSessionGenerator {
+
+    public static String generateTsid() {
+        return TsidCreator.getTsid().toString();
+    }
+}

--- a/backend/src/main/java/com/bether/bether/room/presentation/RoomController.java
+++ b/backend/src/main/java/com/bether/bether/room/presentation/RoomController.java
@@ -19,7 +19,6 @@ import com.bether.bether.room.presentation.dto.response.TotalDateTimeSlotUpdateR
 import com.bether.bether.room.presentation.dto.response.TotalTimeSlotResponse;
 import com.bether.bether.room.presentation.dto.response.UserCreateResponse;
 import com.bether.bether.user.application.dto.output.UserCreateOutput;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -39,28 +38,28 @@ public class RoomController implements RoomControllerSpecification {
     }
 
     @Override
-    public CustomApiResponse<RoomResponse> getBySession(@PathVariable("session") final UUID session) {
+    public CustomApiResponse<RoomResponse> getBySession(@PathVariable("session") final String session) {
         final RoomOutput output = roomApplicationService.getBySession(session);
         return CustomApiResponse.ok(RoomResponse.from(output));
     }
 
     @Override
     public CustomApiResponse<TimeSlotStatisticResponse> generateTimeSlotStatistic(
-            @PathVariable("session") final UUID session) {
+            @PathVariable("session") final String session) {
         final DateTimeSlotStatisticOutput output = roomApplicationService.generateTimeSlotStatistic(session);
         return CustomApiResponse.ok(TimeSlotStatisticResponse.from(output));
     }
 
     @Override
     public CustomApiResponse<TimeSlotRecommendationsResponse> recommendTopTimeSlots(
-            @PathVariable("session") final UUID session) {
+            @PathVariable("session") final String session) {
         final DateTimeSlotRecommendationsOutput output = roomApplicationService.recommendTopTimeSlots(session);
         return CustomApiResponse.ok(TimeSlotRecommendationsResponse.from(output));
     }
 
     @Override
     public CustomApiResponse<Void> createTimeSlots(
-            @PathVariable("session") final UUID session,
+            @PathVariable("session") final String session,
             @RequestBody final TimeSlotCreateRequest request
     ) {
         roomApplicationService.saveTimeSlots(request.toInput(session));
@@ -69,7 +68,7 @@ public class RoomController implements RoomControllerSpecification {
 
     @Override
     public CustomApiResponse<TotalTimeSlotResponse> getByUserName(
-            @PathVariable("session") final UUID session,
+            @PathVariable("session") final String session,
             @RequestParam("name") final String userName
     ) {
         final DateTimeSlots dateTimeSlots = roomApplicationService.getTimeSlotsBySessionAndUserName(session, userName);
@@ -78,14 +77,14 @@ public class RoomController implements RoomControllerSpecification {
 
     @Override
     public CustomApiResponse<TotalDateTimeSlotUpdateResponse> updateTimeSlots(
-            @PathVariable("session") final UUID session,
+            @PathVariable("session") final String session,
             @RequestBody final TimeSlotUpdateRequest request) {
         final DateTimeSlots dateTimeSlots = roomApplicationService.updateTimeSlots(request.toInput(session));
         return CustomApiResponse.ok(TotalDateTimeSlotUpdateResponse.from(dateTimeSlots));
     }
 
     @Override
-    public CustomApiResponse<UserCreateResponse> createUser(@PathVariable("session") final UUID session,
+    public CustomApiResponse<UserCreateResponse> createUser(@PathVariable("session") final String session,
                                                             @RequestBody final UserCreateRequest request) {
         final UserCreateOutput output = roomApplicationService.saveUser(session, request.toInput(session));
         return CustomApiResponse.ok(UserCreateResponse.from(output));

--- a/backend/src/main/java/com/bether/bether/room/presentation/RoomControllerSpecification.java
+++ b/backend/src/main/java/com/bether/bether/room/presentation/RoomControllerSpecification.java
@@ -19,7 +19,6 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.UUID;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -48,13 +47,13 @@ public interface RoomControllerSpecification {
                                                     "endTime": "23:00",
                                                     "deadLine": "2026-07-14T23:00",
                                                     "isPublic": true,
-                                                    "roomSession": "a4b1c2d3-e4f5-6789-0123-456789abcdef"
+                                                    "roomSession": "0MERYHCK3MCYH"
                                                 }
                                             }
                                             """)))
     })
     @GetMapping("/{session}")
-    CustomApiResponse<RoomResponse> getBySession(@PathVariable("session") UUID session);
+    CustomApiResponse<RoomResponse> getBySession(@PathVariable("session") String session);
 
     @Operation(summary = "룸 생성", description = "💡 새로운 룸을 생성합니다.")
     @ApiResponses(value = {
@@ -67,7 +66,7 @@ public interface RoomControllerSpecification {
                                                 "success": true,
                                                 "message": null,
                                                 "result": {
-                                                    "session": "a4b1c2d3-e4f5-6789-0123-456789abcdef"
+                                                    "session": "0MERYHCK3MCYH"
                                                 }
                                             }
                                             """)))})
@@ -114,7 +113,7 @@ public interface RoomControllerSpecification {
                             }
                             """)))})
     @GetMapping("/{session}/time-slots/statistic")
-    CustomApiResponse<TimeSlotStatisticResponse> generateTimeSlotStatistic(@PathVariable("session") UUID session);
+    CustomApiResponse<TimeSlotStatisticResponse> generateTimeSlotStatistic(@PathVariable("session") String session);
 
     @Operation(summary = "추천 시간대 순위 조회", description = "💡 가장 많은 인원이 가능한 시간대를 순위별로 추천받습니다.")
     @ApiResponses(value = {
@@ -139,7 +138,7 @@ public interface RoomControllerSpecification {
                             }
                             """)))})
     @GetMapping("/{session}/time-slots/recommendation")
-    CustomApiResponse<TimeSlotRecommendationsResponse> recommendTopTimeSlots(@PathVariable("session") UUID session);
+    CustomApiResponse<TimeSlotRecommendationsResponse> recommendTopTimeSlots(@PathVariable("session") String session);
 
     @Operation(summary = "사용자 가능 시간 제출", description = "💡 특정 룸에 사용자의 가능 시간을 제출(등록)합니다.")
     @ApiResponses(value = {
@@ -153,7 +152,7 @@ public interface RoomControllerSpecification {
                             }
                             """)))})
     @PostMapping("/{session}/time-slots")
-    CustomApiResponse<Void> createTimeSlots(@PathVariable("session") UUID session,
+    CustomApiResponse<Void> createTimeSlots(@PathVariable("session") String session,
                                             @RequestBody(description = "제출할 사용자의 이름과 가능한 시간 목록을 입력합니다.", required = true, content = @Content(
                                                     examples = @ExampleObject(
                                                             summary = "시간 제출 예시",
@@ -190,7 +189,7 @@ public interface RoomControllerSpecification {
                             }
                             """)))})
     @GetMapping("/{session}/time-slots/user")
-    CustomApiResponse<TotalTimeSlotResponse> getByUserName(@PathVariable("session") UUID session,
+    CustomApiResponse<TotalTimeSlotResponse> getByUserName(@PathVariable("session") String session,
                                                            @RequestParam("name") String userName);
 
     @Operation(summary = "사용자 제출 시간 수정", description = "💡 특정 룸에 사용자가 제출한 시간 정보를 수정합니다.")
@@ -214,7 +213,7 @@ public interface RoomControllerSpecification {
                                     }
                                     """)))})
     @PutMapping("/{session}/time-slots")
-    CustomApiResponse<TotalDateTimeSlotUpdateResponse> updateTimeSlots(@PathVariable("session") final UUID session,
+    CustomApiResponse<TotalDateTimeSlotUpdateResponse> updateTimeSlots(@PathVariable("session") final String session,
                                                                        @RequestBody(description = "수정할 사용자의 이름과 새로운 시간 목록을 입력합니다.", required = true, content = @Content(
                                                                                examples = @ExampleObject(
                                                                                        summary = "시간 수정 예시",
@@ -248,7 +247,7 @@ public interface RoomControllerSpecification {
                                     """)))
     })
     @PostMapping("/{session}/users")
-    CustomApiResponse<UserCreateResponse> createUser(@PathVariable("session") final UUID session,
+    CustomApiResponse<UserCreateResponse> createUser(@PathVariable("session") final String session,
                                                      @RequestBody(description = "생성할 사용자의 이름과 비밀번호를 입력합니다.", required = true,
                                                              content = @Content(
                                                                      examples = @ExampleObject(

--- a/backend/src/main/java/com/bether/bether/room/presentation/dto/request/TimeSlotCreateRequest.java
+++ b/backend/src/main/java/com/bether/bether/room/presentation/dto/request/TimeSlotCreateRequest.java
@@ -3,14 +3,13 @@ package com.bether.bether.room.presentation.dto.request;
 import com.bether.bether.datetimeslot.application.dto.input.DateTimeSlotInput;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.UUID;
 
 public record TimeSlotCreateRequest(
         String userName,
         List<LocalDateTime> dateTimes
 ) {
 
-    public DateTimeSlotInput toInput(final UUID roomSession) {
+    public DateTimeSlotInput toInput(final String roomSession) {
         return new DateTimeSlotInput(roomSession, userName, dateTimes);
     }
 }

--- a/backend/src/main/java/com/bether/bether/room/presentation/dto/request/TimeSlotUpdateRequest.java
+++ b/backend/src/main/java/com/bether/bether/room/presentation/dto/request/TimeSlotUpdateRequest.java
@@ -3,14 +3,13 @@ package com.bether.bether.room.presentation.dto.request;
 import com.bether.bether.datetimeslot.application.dto.input.DateTimeSlotUpdateInput;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.UUID;
 
 public record TimeSlotUpdateRequest(
         String userName,
         List<LocalDateTime> dateTimes
 ) {
 
-    public DateTimeSlotUpdateInput toInput(final UUID roomSession) {
+    public DateTimeSlotUpdateInput toInput(final String roomSession) {
         return new DateTimeSlotUpdateInput(roomSession, userName, dateTimes);
     }
 }

--- a/backend/src/main/java/com/bether/bether/room/presentation/dto/request/UserCreateRequest.java
+++ b/backend/src/main/java/com/bether/bether/room/presentation/dto/request/UserCreateRequest.java
@@ -1,14 +1,13 @@
 package com.bether.bether.room.presentation.dto.request;
 
 import com.bether.bether.user.application.dto.input.UserCreateInput;
-import java.util.UUID;
 
 public record UserCreateRequest(
         String name,
         String password
 ) {
 
-    public UserCreateInput toInput(final UUID roomSession) {
+    public UserCreateInput toInput(final String roomSession) {
         return new UserCreateInput(roomSession, name, password);
     }
 }

--- a/backend/src/main/java/com/bether/bether/room/presentation/dto/response/RoomCreateResponse.java
+++ b/backend/src/main/java/com/bether/bether/room/presentation/dto/response/RoomCreateResponse.java
@@ -7,6 +7,6 @@ public record RoomCreateResponse(
 ) {
 
     public static RoomCreateResponse from(final RoomCreateOutput output) {
-        return new RoomCreateResponse(output.session().toString());
+        return new RoomCreateResponse(output.session());
     }
 }

--- a/backend/src/main/java/com/bether/bether/room/presentation/dto/response/RoomResponse.java
+++ b/backend/src/main/java/com/bether/bether/room/presentation/dto/response/RoomResponse.java
@@ -34,7 +34,7 @@ public record RoomResponse(
                 output.endTime(),
                 output.deadLine(),
                 output.isPublic(),
-                output.roomSession().toString()
+                output.roomSession()
         );
     }
 }

--- a/backend/src/main/java/com/bether/bether/user/application/dto/input/UserCreateInput.java
+++ b/backend/src/main/java/com/bether/bether/user/application/dto/input/UserCreateInput.java
@@ -1,10 +1,9 @@
 package com.bether.bether.user.application.dto.input;
 
 import com.bether.bether.user.domain.User;
-import java.util.UUID;
 
 public record UserCreateInput(
-        UUID roomSession,
+        String roomSession,
         String name,
         String password
 ) {

--- a/backend/src/test/java/com/bether/bether/connection/application/ConnectedRoomApplicationServiceTest.java
+++ b/backend/src/test/java/com/bether/bether/connection/application/ConnectedRoomApplicationServiceTest.java
@@ -10,11 +10,11 @@ import com.bether.bether.connection.discord.infrastructure.DiscordMessageSender;
 import com.bether.bether.connection.domain.ConnectedRoom;
 import com.bether.bether.connection.domain.ConnectedRoomRepository;
 import com.bether.bether.connection.domain.Platform;
+import com.github.f4b6a3.tsid.Tsid;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
-import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -56,22 +56,17 @@ class ConnectedRoomApplicationServiceTest {
         final ConnectedRoomCreateOutput saved = connectedRoomApplicationService.save(input);
 
         // then
-        assertThat(isValidUUID(saved.session().toString()))
+        assertThat(isValidTSID(saved.session()))
                 .isTrue();
 
         final ConnectedRoom connectedRoom = connectedRoomRepository.findBySession(saved.session()).orElseThrow();
         assertThat(connectedRoom.getRoom().getSession()).isEqualTo(saved.session());
     }
 
-    private boolean isValidUUID(final String uuid) {
-        if (uuid == null || uuid.isEmpty()) {
+    private boolean isValidTSID(final String tsid) {
+        if (tsid == null || tsid.isEmpty()) {
             return false;
         }
-        try {
-            UUID.fromString(uuid);
-            return true;
-        } catch (final IllegalArgumentException e) {
-            return false;
-        }
+        return Tsid.isValid(tsid);
     }
 }

--- a/backend/src/test/java/com/bether/bether/datetimeslot/application/service/DateDateTimeSlotServiceTest.java
+++ b/backend/src/test/java/com/bether/bether/datetimeslot/application/service/DateDateTimeSlotServiceTest.java
@@ -14,11 +14,11 @@ import com.bether.bether.datetimeslot.domain.DateTimeSlotRepository;
 import com.bether.bether.datetimeslot.domain.DateTimeSlots;
 import com.bether.bether.room.domain.Room;
 import com.bether.bether.room.domain.RoomRepository;
+import com.bether.bether.room.infrastructure.RoomSessionGenerator;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -176,7 +176,7 @@ class DateDateTimeSlotServiceTest {
                         true
                 ));
 
-        final DateTimeSlotInput input = new DateTimeSlotInput(UUID.randomUUID(), "user",
+        final DateTimeSlotInput input = new DateTimeSlotInput(RoomSessionGenerator.generateTsid(), "user",
                 List.of(LocalDateTime.now(), LocalDateTime.now()));
 
         // when
@@ -275,7 +275,8 @@ class DateDateTimeSlotServiceTest {
                 .toList();
         dateTimeSlotRepository.saveAll(DateTimeSlots.from(existedDateTimeSlot));
 
-        final DateTimeSlotUpdateInput input = new DateTimeSlotUpdateInput(UUID.randomUUID(), userName, updated);
+        final DateTimeSlotUpdateInput input = new DateTimeSlotUpdateInput(RoomSessionGenerator.generateTsid(), userName,
+                updated);
 
         // when
         dateTimeSlotService.updateTimeSlots(room.getId(), input);
@@ -311,7 +312,8 @@ class DateDateTimeSlotServiceTest {
                 LocalDateTime.of(2026, 1, 2, 10, 0),
                 LocalDateTime.of(2026, 1, 2, 11, 0)
         );
-        final DateTimeSlotUpdateInput input = new DateTimeSlotUpdateInput(UUID.randomUUID(), userName, updatedSlots);
+        final DateTimeSlotUpdateInput input = new DateTimeSlotUpdateInput(RoomSessionGenerator.generateTsid(), userName,
+                updatedSlots);
 
         // when
         dateTimeSlotService.updateTimeSlots(room.getId(), input);

--- a/backend/src/test/java/com/bether/bether/room/application/service/RoomApplicationServiceTest.java
+++ b/backend/src/test/java/com/bether/bether/room/application/service/RoomApplicationServiceTest.java
@@ -8,11 +8,11 @@ import com.bether.bether.common.NotFoundException;
 import com.bether.bether.room.application.dto.RoomCreateInput;
 import com.bether.bether.room.application.dto.RoomCreateOutput;
 import com.bether.bether.room.application.dto.RoomOutput;
+import com.github.f4b6a3.tsid.Tsid;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
-import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,7 +43,7 @@ class RoomApplicationServiceTest {
         final RoomCreateOutput saved = roomApplicationService.saveRoom(input);
 
         // then
-        assertThat(isValidUUID(saved.session().toString()))
+        assertThat(isValidTSID(saved.session()))
                 .isTrue();
     }
 
@@ -87,7 +87,7 @@ class RoomApplicationServiceTest {
     @Test
     void getRoomByNotExistedSession() {
         // given
-        final UUID notExistedSession = UUID.fromString("1ac856c2-5236-4439-9f58-c4153a6ecb5d");
+        final String notExistedSession = "not-existed-session";
 
         // when // then
         assertThatThrownBy(() -> roomApplicationService.getBySession(notExistedSession))
@@ -228,15 +228,10 @@ class RoomApplicationServiceTest {
                 .hasMessage("The deadline must be set in 30-minute intervals.");
     }
 
-    private boolean isValidUUID(final String uuid) {
-        if (uuid == null || uuid.isEmpty()) {
+    private boolean isValidTSID(final String tsid) {
+        if (tsid == null || tsid.isEmpty()) {
             return false;
         }
-        try {
-            UUID.fromString(uuid);
-            return true;
-        } catch (final IllegalArgumentException e) {
-            return false;
-        }
+        return Tsid.isValid(tsid);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

-  close #133 
## 📝 작업 내용

> UUID 를 사용하던 기존 room session 필드를 String TSID로 변경

### 요구사항 정리 
**room session 의 필수 속성**
- 고유한 값
- 정렬 가능한 값 
- 가능한 적은 메모리 수
- 최대한 짧은 문자열로 표현

현행: `uuid v4`
후보군: `auto_increment` , `uuid v7`, `snowflake`, `tsid`

| 구분 (Key Type) | 🌍 고유성 (Uniqueness) | 📊 정렬 가능성 (Sortability) | 💾 메모리 사용량 (DB) | 📏 문자열 길이 (Representation) |
| :--- | :--- | :--- | :--- | :--- |
| **`auto_increment`** | 테이블 내에서만 보장 | ✅ 가능 | 8 bytes (`BIGINT`) | 가변적 (예: "12345") |
| **`uuid v4`** | ✅ 전역적 (완전 랜덤) | ❌ 불가능 | 16 bytes (`BINARY(16)`) | 36자 (하이픈 포함) |
| **`uuid v7`** | ✅ 전역적 (시간 + 랜덤) | ✅ 시간순 | 16 bytes (`BINARY(16)`) | 36자 (하이픈 포함) |
| **`snowflake`** | ✅ 전역적 (시간 + 워커 ID) | ✅ 시간순 | 8 bytes (`BIGINT`) | 가변적 (~19자, 숫자) |
| **`tsid`** | ✅ 전역적 (시간 + 노드 ID) | ✅ 시간순 | 8 bytes (`BIGINT`) | **13자 (고정)** |

[TSID](https://github.com/f4b6a3/tsid-creator)가 가장 적절한 상황이라고 생각해 TSID로 결정했습니다.
TSID란 Time-Sorted Unique Identifiers 의 약자로, 다음과 같은 특징이 있습니다. 

- Sorted by generation time;
- Can be stored as an integer of 64 bits;
- Can be stored as a string of 13 chars;
- String format is encoded to [Crockford's base32](https://www.crockford.com/base32.html);
- String format is URL safe, is case insensitive, and has no hyphens;
- Shorter than UUID, ULID and KSUID.

### 스크린샷

<img width="2097" height="860" alt="image" src="https://github.com/user-attachments/assets/d3764fcd-d2b0-47f6-a34d-7a9f64e6b0b8" />


### 참고 자료 
- [snowflake](https://jeongchul.tistory.com/730)
- [TSID](https://github.com/f4b6a3/tsid-creator)
- [다양한 키 생성전략](https://www.rfc-editor.org/rfc/rfc9562.html)
- [키 생성전략 비교](https://jaeseo0519.tistory.com/415)

## 💬 리뷰 요구사항

### Q1.
클래스 네이밍을 `RoomSessionGenerator` 로, room - infra 패키지에 두었습니다.
아직 room 도메인에서만 사용할 것 같아서 두었고, 추후 여기저기 쓰이기 시작하면 common으로 옮기는 것 고려할 예정입니다. 
패키지 위치 및 네이밍에 대해서 더 나은 의견이 있다면 추천 부탁드립니다. 

### Q2.
TSID를 사용하면서 가장 우려했던 점이 외부 의존성이 추가된다는 점인데, 
해당 의존성이 큰 프레임워크를 추가하는 것이 아닌 id를 생성하는 작은 기능만 추가하는 것이고, 
POJO로 직접 구현하는 것 보다 비용 및 구현측면에서 좋다고 생각해 결정했습니다. 
다른 대안이 있거나, 놓친 고려사항이 있다면 의견 부탁드립니다.

### Q3.
인코딩을 추가할 지 여부에 대해 궁금합니다. 
`encodeBase32` 는 Tsid 생성 시 별도 처리 없이 얻을 수 있는 값입니다. [Crockford's base32](https://www.crockford.com/base32.html)
`encodeBase62` 는 이를 base62로 추가 인코딩한 값인데, 고정 13자리인 TSID를 10자로 줄일 수 있다는 장점이 있습니다.
자바에서 지원해주지 않아 외부 라이브러리를 사용해 구현함으로 의존성이 너무 커지는 것 같고,
13자 -> 10자가 편의성에 큰 차이가 없는 것 같아 제외하였습니다. 
```
-------------------------------
Long type = 737211883885449843
encodeBase32 = 0MERT9NQK0MKM
encodeBase62 = sSRAd76Iuv
-------------------------------
```