### PR TITLE
Slack/Discord 메시지 URL 생성 리팩터링

### DIFF
--- a/estime-api/src/main/java/com/estime/estime/connection/application/ConnectedRoomApplicationService.java
+++ b/estime-api/src/main/java/com/estime/estime/connection/application/ConnectedRoomApplicationService.java
@@ -1,11 +1,11 @@
 package com.estime.estime.connection.application;
 
-import com.estime.estime.common.config.WebConfigProperties;
 import com.estime.estime.connection.application.dto.input.ConnectedRoomCreateInput;
 import com.estime.estime.connection.application.dto.input.ConnectedRoomCreatedMessageInput;
 import com.estime.estime.connection.application.dto.output.ConnectedRoomCreateOutput;
 import com.estime.estime.connection.domain.ConnectedRoom;
 import com.estime.estime.connection.domain.Platform;
+import com.estime.estime.connection.util.ConnectionUrlBuilder;
 import com.estime.estime.room.application.service.RoomDomainService;
 import com.estime.estime.room.domain.Room;
 import java.util.Map;
@@ -21,7 +21,7 @@ public class ConnectedRoomApplicationService {
     private final RoomDomainService roomDomainService;
     private final ConnectedRoomDomainService connectedRoomDomainService;
     private final Map<Platform, MessageSender> messageSenders;
-    private final WebConfigProperties webConfigProperties; // TODO rename
+    private final ConnectionUrlBuilder connectionUrlBuilder;
 
     @Transactional
     public ConnectedRoomCreateOutput save(final ConnectedRoomCreateInput input) {
@@ -43,7 +43,7 @@ public class ConnectedRoomApplicationService {
      */
     private void sendConnectedRoomCreatedMessage(final ConnectedRoom connectRoom, final String channelId) {
         final Room room = connectRoom.getRoom();
-        final String shortcut = webConfigProperties.dev() + "check?id=" + room.getSession();
+        final String shortcut = connectionUrlBuilder.buildConnectedRoomCreatedUrl(room.getSession());
         final ConnectedRoomCreatedMessageInput input = ConnectedRoomCreatedMessageInput.of(shortcut, room);
         messageSenders.get(connectRoom.getPlatform()).sendConnectedRoomCreatedMessage(channelId, input);
     }

--- a/estime-api/src/main/java/com/estime/estime/connection/discord/infrastructure/DiscordSlashCommandListener.java
+++ b/estime-api/src/main/java/com/estime/estime/connection/discord/infrastructure/DiscordSlashCommandListener.java
@@ -1,40 +1,36 @@
 package com.estime.estime.connection.discord.infrastructure;
 
-import com.estime.estime.common.config.WebConfigProperties;
 import com.estime.estime.connection.application.dto.input.ConnectedRoomCreateMessageInput;
 import com.estime.estime.connection.discord.application.util.DiscordMessageBuilder;
 import com.estime.estime.connection.domain.Platform;
 import com.estime.estime.connection.domain.PlatformCommand;
+import com.estime.estime.connection.util.ConnectionUrlBuilder;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriComponentsBuilder;
 
 @Component
 @RequiredArgsConstructor
 public class DiscordSlashCommandListener extends ListenerAdapter {
 
-    private final WebConfigProperties webConfigProperties;
+    private final ConnectionUrlBuilder connectionUrlBuilder;
     private final DiscordMessageBuilder discordMessageBuilder;
 
     @Override
     public void onSlashCommandInteraction(final SlashCommandInteractionEvent event) {
         if (event.getName().equals(PlatformCommand.CREATE.getCommand())) {
-            final ConnectedRoomCreateMessageInput input = new ConnectedRoomCreateMessageInput(
-                    // TODO refactor with UTIL class
-                    UriComponentsBuilder.fromUriString(webConfigProperties.dev())
-                            .queryParam("platform", Platform.DISCORD.name())
-                            .queryParam("channelId", event.getChannelId())
-                            .build()
-                            .toUriString()
-            );
-
+            final String shortcut = generateConnectedRoomCreateUrl(event);
+            final ConnectedRoomCreateMessageInput input = new ConnectedRoomCreateMessageInput(shortcut);
             final MessageCreateData messageData = discordMessageBuilder.buildConnectedRoomCreateMessage(input);
             event.reply(messageData)
                     .setEphemeral(true)
                     .queue();
         }
+    }
+
+    private String generateConnectedRoomCreateUrl(final SlashCommandInteractionEvent event) {
+        return connectionUrlBuilder.buildConnectedRoomCreateUrl(Platform.DISCORD, event.getChannelId());
     }
 }

--- a/estime-api/src/main/java/com/estime/estime/connection/slack/application/service/SlackService.java
+++ b/estime-api/src/main/java/com/estime/estime/connection/slack/application/service/SlackService.java
@@ -1,14 +1,13 @@
 package com.estime.estime.connection.slack.application.service;
 
-import com.estime.estime.common.config.WebConfigProperties;
 import com.estime.estime.connection.application.dto.input.ConnectedRoomCreateMessageInput;
 import com.estime.estime.connection.domain.Platform;
 import com.estime.estime.connection.domain.PlatformCommand;
 import com.estime.estime.connection.slack.application.dto.SlackSlashCommandInput;
 import com.estime.estime.connection.slack.infrastructure.SlackMessageSender;
+import com.estime.estime.connection.util.ConnectionUrlBuilder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.web.util.UriComponentsBuilder;
 
 @Service
 @RequiredArgsConstructor
@@ -16,13 +15,13 @@ public class SlackService {
 
     private static final String UNSUPPORTED_COMMAND_MESSAGE = "지원하지 않는 아인슈타임 슬랙 커맨드입니다.";
 
-    private final WebConfigProperties webConfigProperties;
+    private final ConnectionUrlBuilder connectionUrlBuilder;
     private final SlackMessageSender slackMessageSender;
 
     public void handleSlashCommand(final SlackSlashCommandInput input) {
         if (PlatformCommand.CREATE.getCommandWithSlash().equals(input.command())) {
-            final String url = generateConnectedRoomCreateUrl(input);
-            final ConnectedRoomCreateMessageInput messageInput = new ConnectedRoomCreateMessageInput(url);
+            final String shortcut = generateConnectedRoomCreateUrl(input);
+            final ConnectedRoomCreateMessageInput messageInput = new ConnectedRoomCreateMessageInput(shortcut);
             slackMessageSender.sendConnectedRoomCreateEphemeralMessage(input.channelId(), input.userId(), messageInput);
         } else {
             slackMessageSender.sendTextMessage(input.channelId(), UNSUPPORTED_COMMAND_MESSAGE);
@@ -30,11 +29,6 @@ public class SlackService {
     }
 
     private String generateConnectedRoomCreateUrl(final SlackSlashCommandInput input) {
-        // TODO refactor with UTIL class
-        return UriComponentsBuilder.fromUriString(webConfigProperties.dev())
-                .queryParam("platform", Platform.SLACK.name())
-                .queryParam("channelId", input.channelId())
-                .build()
-                .toUriString();
+        return connectionUrlBuilder.buildConnectedRoomCreateUrl(Platform.SLACK, input.channelId());
     }
 }

--- a/estime-api/src/main/java/com/estime/estime/connection/util/ConnectionUrlBuilder.java
+++ b/estime-api/src/main/java/com/estime/estime/connection/util/ConnectionUrlBuilder.java
@@ -1,0 +1,33 @@
+package com.estime.estime.connection.util;
+
+import com.estime.estime.common.config.WebConfigProperties;
+import com.estime.estime.connection.domain.Platform;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+public class ConnectionUrlBuilder {
+
+    private final String baseUrl;
+
+    public ConnectionUrlBuilder(final WebConfigProperties properties) {
+        this.baseUrl = properties.prod();
+    }
+
+    public String buildConnectedRoomCreateUrl(final Platform platform, final String channelId) {
+        return UriComponentsBuilder.fromUriString(baseUrl)
+                .queryParam("platform", platform.name())
+                .queryParam("channelId", channelId)
+                .build()
+                .toUriString();
+    }
+
+    public String buildConnectedRoomCreatedUrl(final String session) {
+        return UriComponentsBuilder.fromUriString(baseUrl + "check")
+                .queryParam("id", session)
+                .build()
+                .toUriString();
+    }
+}
+
+

--- a/estime-api/src/main/java/com/estime/estime/room/presentation/RoomController.java
+++ b/estime-api/src/main/java/com/estime/estime/room/presentation/RoomController.java
@@ -7,16 +7,16 @@ import com.estime.estime.datetimeslot.domain.DateTimeSlots;
 import com.estime.estime.room.application.dto.RoomCreateOutput;
 import com.estime.estime.room.application.dto.RoomOutput;
 import com.estime.estime.room.application.service.RoomApplicationService;
-import com.estime.estime.room.presentation.dto.request.RoomCreateRequest;
 import com.estime.estime.room.presentation.dto.request.DateTimeSlotCreateRequest;
 import com.estime.estime.room.presentation.dto.request.DateTimeSlotUpdateRequest;
+import com.estime.estime.room.presentation.dto.request.RoomCreateRequest;
 import com.estime.estime.room.presentation.dto.request.UserCreateRequest;
-import com.estime.estime.room.presentation.dto.response.RoomCreateResponse;
-import com.estime.estime.room.presentation.dto.response.RoomResponse;
 import com.estime.estime.room.presentation.dto.response.DateTimeSlotRecommendationsResponse;
 import com.estime.estime.room.presentation.dto.response.DateTimeSlotStatisticResponse;
-import com.estime.estime.room.presentation.dto.response.TotalDateTimeSlotUpdateResponse;
+import com.estime.estime.room.presentation.dto.response.RoomCreateResponse;
+import com.estime.estime.room.presentation.dto.response.RoomResponse;
 import com.estime.estime.room.presentation.dto.response.TotalDateTimeSlotResponse;
+import com.estime.estime.room.presentation.dto.response.TotalDateTimeSlotUpdateResponse;
 import com.estime.estime.room.presentation.dto.response.UserCreateResponse;
 import com.estime.estime.user.application.dto.output.UserCreateOutput;
 import lombok.RequiredArgsConstructor;
@@ -71,7 +71,8 @@ public class RoomController implements RoomControllerSpecification {
             @PathVariable("session") final String session,
             @RequestParam("name") final String userName
     ) {
-        final DateTimeSlots dateTimeSlots = roomApplicationService.getDateTimeSlotsBySessionAndUserName(session, userName);
+        final DateTimeSlots dateTimeSlots = roomApplicationService.getDateTimeSlotsBySessionAndUserName(session,
+                userName);
         return CustomApiResponse.ok(TotalDateTimeSlotResponse.from(dateTimeSlots));
     }
 

--- a/estime-api/src/main/java/com/estime/estime/room/presentation/RoomControllerSpecification.java
+++ b/estime-api/src/main/java/com/estime/estime/room/presentation/RoomControllerSpecification.java
@@ -1,16 +1,16 @@
 package com.estime.estime.room.presentation;
 
 import com.estime.estime.common.CustomApiResponse;
-import com.estime.estime.room.presentation.dto.request.RoomCreateRequest;
 import com.estime.estime.room.presentation.dto.request.DateTimeSlotCreateRequest;
 import com.estime.estime.room.presentation.dto.request.DateTimeSlotUpdateRequest;
+import com.estime.estime.room.presentation.dto.request.RoomCreateRequest;
 import com.estime.estime.room.presentation.dto.request.UserCreateRequest;
-import com.estime.estime.room.presentation.dto.response.RoomCreateResponse;
-import com.estime.estime.room.presentation.dto.response.RoomResponse;
 import com.estime.estime.room.presentation.dto.response.DateTimeSlotRecommendationsResponse;
 import com.estime.estime.room.presentation.dto.response.DateTimeSlotStatisticResponse;
-import com.estime.estime.room.presentation.dto.response.TotalDateTimeSlotUpdateResponse;
+import com.estime.estime.room.presentation.dto.response.RoomCreateResponse;
+import com.estime.estime.room.presentation.dto.response.RoomResponse;
 import com.estime.estime.room.presentation.dto.response.TotalDateTimeSlotResponse;
+import com.estime.estime.room.presentation.dto.response.TotalDateTimeSlotUpdateResponse;
 import com.estime.estime.room.presentation.dto.response.UserCreateResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -113,7 +113,8 @@ public interface RoomControllerSpecification {
                             }
                             """)))})
     @GetMapping("/{session}/time-slots/statistic")
-    CustomApiResponse<DateTimeSlotStatisticResponse> generateDateTimeSlotStatistic(@PathVariable("session") String session);
+    CustomApiResponse<DateTimeSlotStatisticResponse> generateDateTimeSlotStatistic(
+            @PathVariable("session") String session);
 
     @Operation(summary = "추천 시간대 순위 조회", description = "💡 가장 많은 인원이 가능한 시간대를 순위별로 추천받습니다.")
     @ApiResponses(value = {
@@ -138,7 +139,8 @@ public interface RoomControllerSpecification {
                             }
                             """)))})
     @GetMapping("/{session}/time-slots/recommendation")
-    CustomApiResponse<DateTimeSlotRecommendationsResponse> recommendTopDateTimeSlots(@PathVariable("session") String session);
+    CustomApiResponse<DateTimeSlotRecommendationsResponse> recommendTopDateTimeSlots(
+            @PathVariable("session") String session);
 
     @Operation(summary = "사용자 가능 시간 제출", description = "💡 특정 룸에 사용자의 가능 시간을 제출(등록)합니다.")
     @ApiResponses(value = {
@@ -154,21 +156,21 @@ public interface RoomControllerSpecification {
     @PostMapping("/{session}/time-slots")
     CustomApiResponse<Void> createDateTimeSlots(@PathVariable("session") String session,
                                                 @RequestBody(description = "제출할 사용자의 이름과 가능한 시간 목록을 입력합니다.", required = true, content = @Content(
-                                                    examples = @ExampleObject(
-                                                            summary = "시간 제출 예시",
-                                                            value = """
-                                                                    {
-                                                                        "userName": "강감찬",
-                                                                        "dateTimes": [
-                                                                            "2025-07-21T14:00",
-                                                                            "2025-07-21T15:00",
-                                                                            "2025-07-22T18:00",
-                                                                            "2025-07-22T19:00"
-                                                                        ]
-                                                                    }
-                                                                    """
-                                                    )
-                                            )) DateTimeSlotCreateRequest request);
+                                                        examples = @ExampleObject(
+                                                                summary = "시간 제출 예시",
+                                                                value = """
+                                                                        {
+                                                                            "userName": "강감찬",
+                                                                            "dateTimes": [
+                                                                                "2025-07-21T14:00",
+                                                                                "2025-07-21T15:00",
+                                                                                "2025-07-22T18:00",
+                                                                                "2025-07-22T19:00"
+                                                                            ]
+                                                                        }
+                                                                        """
+                                                        )
+                                                )) DateTimeSlotCreateRequest request);
 
     @Operation(summary = "특정 사용자 제출 시간 조회", description = "💡 룸에서 특정 사용자 이름으로 제출된 시간 정보를 조회합니다.")
     @ApiResponses(value = {
@@ -213,22 +215,23 @@ public interface RoomControllerSpecification {
                                     }
                                     """)))})
     @PutMapping("/{session}/time-slots")
-    CustomApiResponse<TotalDateTimeSlotUpdateResponse> updateDateTimeSlots(@PathVariable("session") final String session,
-                                                                           @RequestBody(description = "수정할 사용자의 이름과 새로운 시간 목록을 입력합니다.", required = true, content = @Content(
-                                                                               examples = @ExampleObject(
-                                                                                       summary = "시간 수정 예시",
-                                                                                       value = """
-                                                                                               {
-                                                                                                   "userName": "강감찬",
-                                                                                                   "dateTimes": [
-                                                                                                       "2025-07-21T16:00",
-                                                                                                       "2025-07-21T17:00",
-                                                                                                       "2025-07-22T20:00"
-                                                                                                   ]
-                                                                                               }
-                                                                                               """
-                                                                               )
-                                                                       )) DateTimeSlotUpdateRequest request);
+    CustomApiResponse<TotalDateTimeSlotUpdateResponse> updateDateTimeSlots(
+            @PathVariable("session") final String session,
+            @RequestBody(description = "수정할 사용자의 이름과 새로운 시간 목록을 입력합니다.", required = true, content = @Content(
+                    examples = @ExampleObject(
+                            summary = "시간 수정 예시",
+                            value = """
+                                    {
+                                        "userName": "강감찬",
+                                        "dateTimes": [
+                                            "2025-07-21T16:00",
+                                            "2025-07-21T17:00",
+                                            "2025-07-22T20:00"
+                                        ]
+                                    }
+                                    """
+                    )
+            )) DateTimeSlotUpdateRequest request);
 
 
     @Operation(summary = "룸 사용자 로그인", description = "💡 특정 룸에 새로운 사용자를 생성(로그인)합니다. 사용자는 이름과 비밀번호로 식별됩니다.")

--- a/estime-api/src/test/java/com/estime/estime/datetimeslot/application/service/DateTimeSlotServiceTest.java
+++ b/estime-api/src/test/java/com/estime/estime/datetimeslot/application/service/DateTimeSlotServiceTest.java
@@ -257,7 +257,8 @@ class DateTimeSlotServiceTest {
     @DisplayName("특정 사용자가 저장한 DT슬롯을 제시한 날짜로 변경할 수 있다.")
     @ParameterizedTest(name = "{0}")
     @MethodSource(value = "provideUpdateDateTimeSlotsArguments")
-    void updateDateTimeSlots(final String testName, final List<LocalDateTime> existed, final List<LocalDateTime> updated) {
+    void updateDateTimeSlots(final String testName, final List<LocalDateTime> existed,
+                             final List<LocalDateTime> updated) {
         // given
         final Room room = roomRepository.save(
                 Room.withoutId(


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #245 

## 📝 작업 내용

- ConnectedRoom URL 생성 로직을 ConnectionUrlBuilder로 분리 (Slack/Discord 공통)
- ConnectedRoom URL의 base URL을 prod 환경의 base URL과 동일하게 수정

## 💬 리뷰 요구사항
