### PR TITLE
마감기한 시간 추가 및 설명 텍스트 크기 수정

### DIFF
--- a/frontend/src/components/CheckEventPageHeader/index.tsx
+++ b/frontend/src/components/CheckEventPageHeader/index.tsx
@@ -34,15 +34,15 @@ const CheckEventPageHeader = ({
             <ILock color={theme.colors.text} />
           )}
 
-          <Text variant="body" color="text">
+          <Text variant="h4" color="text">
             공개 여부 : {isPublic === 'public' ? '공개' : '비공개'}
           </Text>
         </Flex>
         <Flex justify="space-between" align="center" gap="var(--gap-3)">
           <IClock color={theme.colors.text} />
 
-          <Text variant="body" color="text">
-            마감일 : {deadLine ? deadLine.date : '설정되지 않음'}
+          <Text variant="h4" color="text">
+            마감일 : {deadLine ? `${deadLine.date} ${deadLine.time}` : '설정되지 않음'}
           </Text>
         </Flex>
       </Flex>

--- a/frontend/src/components/LoginSuggestModal/index.tsx
+++ b/frontend/src/components/LoginSuggestModal/index.tsx
@@ -38,7 +38,7 @@ const LoginSuggestModal = ({ target, isOpen, onClose, onLoginClick }: LoginSugge
           <Modal.Content>
             <Flex direction="column" gap="var(--gap-6)" align="center">
               <Text variant="h2">로그인하고 내 일정을 등록하세요.</Text>
-              <Text variant="body" color="gray50">
+              <Text variant="h4" color="gray50">
                 이름과 (선택적으로) 비밀번호를 입력하여 내 응답을 저장하고 나중에 수정할 수
                 있습니다.
               </Text>

--- a/frontend/src/components/Sections/BasicSettings/index.tsx
+++ b/frontend/src/components/Sections/BasicSettings/index.tsx
@@ -36,7 +36,7 @@ const BasicSettings = ({ title, time }: BasicSettingsProps) => {
       <S.InfoWrapper>
         <S.TextWrapper>
           <Text variant="h3">방 제목</Text>
-          <Text variant="body">참여자들에게 표시될 방의 제목을 입력해주세요.</Text>
+          <Text variant="h4">참여자들에게 표시될 방의 제목을 입력해주세요.</Text>
         </S.TextWrapper>
         <S.InputWrapper>
           <Input
@@ -49,7 +49,7 @@ const BasicSettings = ({ title, time }: BasicSettingsProps) => {
       <S.InfoWrapper>
         <S.TextWrapper>
           <Text variant="h3">시간 선택</Text>
-          <Text variant="body">참여자가 선택할 수 있는 시간의 범위를 설정합니다.</Text>
+          <Text variant="h4">참여자가 선택할 수 있는 시간의 범위를 설정합니다.</Text>
         </S.TextWrapper>
         <S.ButtonWrapper>
           <Button

--- a/frontend/src/components/Sections/CalendarSettings/index.tsx
+++ b/frontend/src/components/Sections/CalendarSettings/index.tsx
@@ -26,7 +26,7 @@ const CalendarSettings = ({ availableDates }: CalendarSettingsProps) => {
     <S.Container>
       <S.TextWrapper>
         <Text variant="h3">날짜 선택</Text>
-        <Text variant="body">가능한 날짜를 드래그해서 선택해주세요!</Text>
+        <Text variant="h4">가능한 날짜를 드래그해서 선택해주세요!</Text>
       </S.TextWrapper>
       <Calender today={today} selectedDates={availableDates.value} mouseHandlers={mouseHandlers} />
     </S.Container>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #289 


## 📝 작업 내용

- [x] 텍스트 크기 `body -> h4`로 수정
  - 달력 아래 설명 텍스트 (방 생성 페이지)
  - 방 제목 작성 아래 설명 텍스트 (방 생성 페이지)
  - 시간 선택 아래 설명 텍스트 (방 생성 페이지)
  - 마감기한 텍스트 (방 체크 페이지)
  - 로그인 모달 아래 설명 텍스트 (방 체크 페이지)
- [x] 마감기한 시간 추가

## 📷 수정 후 텍스트 크기 
<img width="1453" height="827" alt="image" src="https://github.com/user-attachments/assets/fce01a8a-f73d-4b52-84e5-fe4ba603a593" />
<img width="1387" height="815" alt="image" src="https://github.com/user-attachments/assets/30593494-b848-4b00-babf-f6d960983e59" />

## 💬 리뷰 요구사항
