### PR TITLE
달력 날짜 선택 최대 7일

### DIFF
--- a/frontend/src/components/Calendar/Calendar.styled.ts
+++ b/frontend/src/components/Calendar/Calendar.styled.ts
@@ -65,5 +65,4 @@ export const Header = styled.header`
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  margin-bottom: var(--gap-6);
 `;

--- a/frontend/src/components/Calendar/DayCell/DayCell.styled.tsx
+++ b/frontend/src/components/Calendar/DayCell/DayCell.styled.tsx
@@ -9,6 +9,7 @@ interface DayCellProps {
   isToday: boolean;
   isSelected: boolean;
   isEmpty: boolean;
+  isDateBlockedByLimit: boolean;
 }
 
 export const Container = styled.div<DayCellProps>`
@@ -48,4 +49,12 @@ export const Container = styled.div<DayCellProps>`
     cursor: ${({ isPast, isEmpty }) => (isPast || isEmpty ? 'not-allowed' : 'grab')};
   }
   transform: ${({ isSelected }) => (isSelected ? 'scale(1.05)' : 'scale(1)')};
+
+  ${({ isDateBlockedByLimit }) =>
+    isDateBlockedByLimit &&
+    `
+    pointer-events: none;
+    opacity: 0.3;
+
+  `}
 `;

--- a/frontend/src/components/Calendar/DayCell/index.tsx
+++ b/frontend/src/components/Calendar/DayCell/index.tsx
@@ -28,6 +28,7 @@ const DayCell = ({
       isToday={dayState.isToday}
       isSelected={dayState.isSelected}
       isEmpty={dayState.isEmpty}
+      isDateBlockedByLimit={dayState.isDateBlockedByLimit}
       onMouseDown={() => onMouseDown(day)}
       onMouseEnter={() => onMouseEnter(day)}
       onMouseUp={onMouseUp}

--- a/frontend/src/components/Calendar/index.tsx
+++ b/frontend/src/components/Calendar/index.tsx
@@ -8,6 +8,7 @@ import DayCell from './DayCell';
 import Text from '@/components/Text';
 import IChevronLeft from '@/icons/IChevronLeft';
 import IChevronRight from '@/icons/IChevronRight';
+import Flex from '../Layout/Flex';
 
 interface CalenderProps {
   today: Date;
@@ -25,40 +26,45 @@ const Calender = ({ today, selectedDates, mouseHandlers }: CalenderProps) => {
   const { onMouseDown, onMouseEnter, onMouseUp, onMouseLeave } = mouseHandlers;
   return (
     <S.Container>
-      <S.Header>
-        <Text variant="h2">
-          {current.toLocaleDateString('ko-KR', { month: 'long', year: 'numeric' })}
-        </Text>
-        <S.ButtonContainer>
-          <CalendarButton onClick={prevMonth} disabled={isItCurrentMonth(current, today)}>
-            <IChevronLeft width={20} height={20} />
-          </CalendarButton>
-          <CalendarButton onClick={nextMonth}>
-            <IChevronRight width={20} height={20} />
-          </CalendarButton>
-        </S.ButtonContainer>
-      </S.Header>
-      <S.CalendarContainer>
-        <S.Grid onMouseLeave={onMouseLeave}>
-          {weekdays.map((w) => (
-            <S.Weekday key={w} isSunday={w === '일'} isSaturday={w === '토'}>
-              {w}
-            </S.Weekday>
-          ))}
+      <Flex direction="column" gap="var(--gap-5)">
+        <Flex direction="column" gap="var(--gap-4)">
+          <S.Header>
+            <Text variant="h2">
+              {current.toLocaleDateString('ko-KR', { month: 'long', year: 'numeric' })}
+            </Text>
+            <S.ButtonContainer>
+              <CalendarButton onClick={prevMonth} disabled={isItCurrentMonth(current, today)}>
+                <IChevronLeft width={20} height={20} />
+              </CalendarButton>
+              <CalendarButton onClick={nextMonth}>
+                <IChevronRight width={20} height={20} />
+              </CalendarButton>
+            </S.ButtonContainer>
+          </S.Header>
+          <Text variant="h4">날짜는 최대 7개까지 선택 가능합니다.</Text>
+        </Flex>
+        <S.CalendarContainer>
+          <S.Grid onMouseLeave={onMouseLeave}>
+            {weekdays.map((w) => (
+              <S.Weekday key={w} isSunday={w === '일'} isSaturday={w === '토'}>
+                {w}
+              </S.Weekday>
+            ))}
 
-          {monthMatrix.flat().map((day, i) => (
-            <DayCell
-              key={i}
-              day={day}
-              today={today}
-              selectedDates={selectedDates}
-              onMouseDown={onMouseDown}
-              onMouseEnter={onMouseEnter}
-              onMouseUp={onMouseUp}
-            />
-          ))}
-        </S.Grid>
-      </S.CalendarContainer>
+            {monthMatrix.flat().map((day, i) => (
+              <DayCell
+                key={i}
+                day={day}
+                today={today}
+                selectedDates={selectedDates}
+                onMouseDown={onMouseDown}
+                onMouseEnter={onMouseEnter}
+                onMouseUp={onMouseUp}
+              />
+            ))}
+          </S.Grid>
+        </S.CalendarContainer>
+      </Flex>
     </S.Container>
   );
 };

--- a/frontend/src/hooks/Calendar/useDayState.ts
+++ b/frontend/src/hooks/Calendar/useDayState.ts
@@ -1,4 +1,4 @@
-import { isItPast, isToday } from '@/utils/Calendar/dateUtils';
+import { isDateBlockedByLimit, isItPast, isToday } from '@/utils/Calendar/dateUtils';
 import { formatDateToString } from '@/utils/Calendar/format';
 
 interface UseDayStateProps {
@@ -17,6 +17,7 @@ export const useDayState = ({ day, today, selectedDates }: UseDayStateProps) => 
       isSelected: false,
       isEmpty: true,
       dateString: '',
+      isDateBlockedByLimit: false,
     };
   }
 
@@ -28,5 +29,6 @@ export const useDayState = ({ day, today, selectedDates }: UseDayStateProps) => 
     isSelected: selectedDates.has(formatDateToString(day)),
     isEmpty: false,
     dateString: day.getDate().toString(),
+    isDateBlockedByLimit: isDateBlockedByLimit(day, selectedDates),
   };
 };

--- a/frontend/src/utils/Calendar/dateUtils.ts
+++ b/frontend/src/utils/Calendar/dateUtils.ts
@@ -1,3 +1,5 @@
+import { formatDateToString } from './format';
+
 const isToday = (day: Date | null, today: Date) => {
   if (!day) return false;
   return (
@@ -21,4 +23,16 @@ const isValidDate = (day: Date | null) => {
   return day instanceof Date && !isNaN(day.getTime());
 };
 
-export { isItCurrentMonth, isItPast, isToday, isValidDate };
+const hasReachedMaxSelection = (selectedDates: Set<string>) => {
+  return selectedDates.size === 7;
+};
+
+const isDateBlockedByLimit = (day: Date | null, selectedDates: Set<string>) => {
+  if (!day) return false;
+  if (hasReachedMaxSelection(selectedDates)) {
+    return !selectedDates.has(formatDateToString(day));
+  }
+  return false;
+};
+
+export { isItCurrentMonth, isItPast, isToday, isValidDate, isDateBlockedByLimit };


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #287 

## 📝 작업 내용
- [x] 달력 월 밑에 “날짜는 최대 7일까지 선택 가능합니다.” 안내 문구 추가
- [x] 안내 문구 추가에 맞게 달력 섹션 스타일 수정
- [x] 최대 7일 선택이 되었는지 확인하는 유틸 함수 추가
- [x] 최대 7일 선택된 날짜에 포함된 날짜인지 확인하는 유틸함수 추가
    → 이 부분은 포함된 날짜가 아니면 날짜 선택을 할 수 없도록 하기 위해서 추가한 함수입니다!
- [x] 최대 7일 선택 시 다른 날짜 선택 할 수 없도록 DayCell 스타일 추가  

## 💬 논의하고 싶은 부분
- 지금 날짜 선택이 최대 7일까지 선택이 완료된 경우 다른 날짜가 선택이 안되는 게 명확히 보였으면 해서 스타일로 선택을 막아놓은 상태입니다!
- 달력 월 밑에 "달력 날짜는 최대 7일까지 가능합니다."라는 안내 문구를 추가해두긴 했지만 사용자 입장에서 추가로 안내 모달 같은 띄어주는 것이 좋을지 같이 이야기 나눠보면 좋을 것 같습니다.

## 📷 참고 이미지
<img width="602" height="696" alt="image" src="https://github.com/user-attachments/assets/d03c9df7-96a2-4dd1-8eeb-d2861f7323c7" />


## 💬 리뷰 요구사항
