### PR TITLE
pretendard 폰트 외부 CDN 서버 이용

### DIFF
--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -1,15 +1,16 @@
 @import url('./reset.css');
+@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css');
 
-@font-face {
+/* @font-face {
   font-family: 'Pretendard';
   font-weight: 45 920;
   font-style: normal;
   font-display: swap;
   src: url('./font/PretendardVariable.woff2') format('woff2-variations');
-}
+} */
 
 body {
-  font-family: 'Pretendard', sans-serif;
+  font-family: 'Pretendard Variable', sans-serif;
 }
 
 :root {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#282 

## 📝 작업 내용
- pretendard 외부 CDN 서버 주소 추가

## 건의사항
1. 기본적으로 브라우저는 폰트를 캐싱하기 때문에 초기 웹 접근이 아닌 경우엔  트래픽에 아무런 영향을 주지 않는다고 합니다.
### 초기 접근
<img width="887" height="173" alt="스크린샷 2025-08-03 오전 2 13 52" src="https://github.com/user-attachments/assets/c5fe7f5e-0783-4e20-bf8e-e1efda5b34bb" />

### 이후 접근
<img width="697" height="173" alt="스크린샷 2025-08-03 오전 2 42 44" src="https://github.com/user-attachments/assets/1b794f09-c8fd-4448-849c-665a795478f0" />

### 외부 CDN 서버의 초기 접근 (브라우저에 캐싱이 안되어 있다면)
<img width="1060" height="249" alt="스크린샷 2025-08-03 오전 2 56 49" src="https://github.com/user-attachments/assets/d689901e-53c2-4afb-9b15-2f0a2919f3d1" />
-> 위 이미지 보시다시피 용량은 동일합니다.

2. 외부 CDN 서버를 이용하면 오히려 네트워크 요청을 추가로 보내야하기 때문에 폰트 적용에 있어 깜박임 현상이 있을 수 있습니다. 

https://github.com/user-attachments/assets/9580234b-3fc2-49dc-9a49-e363d0621916


3. 다만, 외부 CDN에서 제공하는 Pretendard 폰트는 브라우저에 캐시되므로, 사용자가 다른 사이트에서 해당 폰트를 이미 로드한 경험이 있다면, 저희 서비스 초기 진입자들은 이 캐싱된 정보를 보고 초기 진입임에도 불구하고 바로 볼 가능성이 있습니다.

## 질문 있습니다. 
- 저희 서비스도 CDN을 통해서 관리되고 있는데, 폰트가 서비스내에 존재하면 저희 폰트도 CDN을 통해서 가져오는게 아닌가요??
- 일단 cdn 주소는 추가해놨으나, 리뷰를 통해 반영 여부를 결정하겠습니다!