### PR TITLE
통계 API 반환 시 전체 인원 수 데이터 추가

### DIFF
--- a/estime-api/src/main/java/com/estime/room/application/dto/output/DateTimeSlotStatisticOutput.java
+++ b/estime-api/src/main/java/com/estime/room/application/dto/output/DateTimeSlotStatisticOutput.java
@@ -4,6 +4,7 @@ import com.estime.room.domain.vo.DateTimeSlot;
 import java.util.List;
 
 public record DateTimeSlotStatisticOutput(
+        int totalParticipant,
         List<DateTimeParticipantsOutput> statistic
 ) {
 

--- a/estime-api/src/main/java/com/estime/room/application/service/RoomApplicationService.java
+++ b/estime-api/src/main/java/com/estime/room/application/service/RoomApplicationService.java
@@ -66,6 +66,7 @@ public class RoomApplicationService {
                 .collect(Collectors.toMap(Participant::getId, Participant::getName));
 
         return new DateTimeSlotStatisticOutput(
+                participantIds.size(),
                 dateTimeSlotParticipants.keySet().stream()
                         .map(dateTimeSlot ->
                                 new DateTimeParticipantsOutput(

--- a/estime-api/src/main/java/com/estime/room/presentation/dto/response/DateTimeSlotStatisticResponse.java
+++ b/estime-api/src/main/java/com/estime/room/presentation/dto/response/DateTimeSlotStatisticResponse.java
@@ -8,11 +8,14 @@ import java.util.Comparator;
 import java.util.List;
 
 public record DateTimeSlotStatisticResponse(
+        @Schema(example = "5")
+        int totalParticipant,
         List<DateTimeSlotVotesResponse> statistic
 ) {
 
     public static DateTimeSlotStatisticResponse from(final DateTimeSlotStatisticOutput output) {
         return new DateTimeSlotStatisticResponse(
+                output.totalParticipant(),
                 output.statistic()
                         .stream()
                         .map(each -> new DateTimeSlotVotesResponse(


### PR DESCRIPTION
## #️⃣ 연관된 이슈

-close #319 

## 📝 작업 내용

통계 반환 응답데이터에 전체 참여자 수 데이터를 추가합니다.

<img width="2100" height="1103" alt="image" src="https://github.com/user-attachments/assets/df5d99d4-baf1-4dbd-bc57-b9e563f0c9a0" />

## 💬 리뷰 요구사항

`totalParticipant` 보다 더 좋은 변수명 추천부탁드립니다. 

