### PR TITLE
api 성능 측정 의존성 수정

### DIFF
--- a/estime-api/build.gradle
+++ b/estime-api/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
-    implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'io.micrometer:micrometer-registry-cloudwatch2'
 }
 
 tasks.named('test') {

--- a/estime-api/src/main/resources/application.yml
+++ b/estime-api/src/main/resources/application.yml
@@ -48,10 +48,9 @@ management:
   endpoints:
     web:
       exposure:
-        include: health, prometheus
+        include: health, metrics
   metrics:
-    distribution:
-      percentiles-histogram:
-        http.server.requests: true
-      sla:
-        http.server.requests: 50ms, 100ms, 500ms
+    export:
+      cloudwatch:
+        namespace: "aws/ec2/estime-api-dev"
+        region: ap-northeast-2


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #309 

## 📝 작업 내용

cloudwatch agent 설정 불가로 인해 micrometer를 prometheus -> cloudwatch2 로 변경하였습니다. 

## 💬 리뷰 요구사항
