### PR TITLE
spring 프로퍼티 설정 내 cloudwatch namespace 수정

### DIFF
--- a/estime-api/src/main/resources/application.yml
+++ b/estime-api/src/main/resources/application.yml
@@ -48,9 +48,9 @@ management:
   endpoints:
     web:
       exposure:
-        include: health, metrics
+        include: "health, info, metrics"
   metrics:
     export:
       cloudwatch:
-        namespace: "aws/ec2/estime-api-dev"
+        namespace: "EC2/estime-api/dev"
         region: ap-northeast-2


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #309

## 📝 작업 내용

namespace에 aws 접두사를 사용하면 cloudwatch 지표에 잡히지 않는 문제가 존재하여 변경하였습니다.

aws 접두사 없이 고유한 이름을 사용하는 것이 AWS 모범 사례이므로 namespace 수정했습니다.

## 💬 리뷰 요구사항
