### PR TITLE
참여자 닉네임 중복 검증 API와 생성 API를 통합

### DIFF
--- a/estime-api/src/main/java/com/estime/room/application/dto/output/ParticipantCheckOutput.java
+++ b/estime-api/src/main/java/com/estime/room/application/dto/output/ParticipantCheckOutput.java
@@ -1,10 +1,10 @@
 package com.estime.room.application.dto.output;
 
 public record ParticipantCheckOutput(
-        boolean exists
+        boolean isDuplicateName
 ) {
 
-    public static ParticipantCheckOutput from(final boolean exists) {
-        return new ParticipantCheckOutput(exists);
+    public static ParticipantCheckOutput from(final boolean isDuplicateName) {
+        return new ParticipantCheckOutput(isDuplicateName);
     }
 }

--- a/estime-api/src/main/java/com/estime/room/domain/participant/Participant.java
+++ b/estime-api/src/main/java/com/estime/room/domain/participant/Participant.java
@@ -36,6 +36,6 @@ public class Participant extends BaseEntity {
             final String name
     ) {
         Objects.requireNonNull(roomId, "roomId cannot be null");
-        Objects.requireNonNull(name, "participantName cannot be null");
+        Objects.requireNonNull(name, "name cannot be null");
     }
 }

--- a/estime-api/src/main/java/com/estime/room/presentation/RoomController.java
+++ b/estime-api/src/main/java/com/estime/room/presentation/RoomController.java
@@ -3,7 +3,6 @@ package com.estime.room.presentation;
 import com.estime.common.CustomApiResponse;
 import com.estime.room.application.dto.output.DateTimeSlotStatisticOutput;
 import com.estime.room.application.dto.output.ParticipantCheckOutput;
-import com.estime.room.application.dto.output.ParticipantCreateOutput;
 import com.estime.room.application.dto.output.RoomCreateOutput;
 import com.estime.room.application.dto.output.RoomOutput;
 import com.estime.room.application.service.RoomApplicationService;
@@ -13,7 +12,6 @@ import com.estime.room.presentation.dto.request.ParticipantVotesUpdateRequest;
 import com.estime.room.presentation.dto.request.RoomCreateRequest;
 import com.estime.room.presentation.dto.response.DateTimeSlotStatisticResponse;
 import com.estime.room.presentation.dto.response.ParticipantCheckResponse;
-import com.estime.room.presentation.dto.response.ParticipantCreateResponse;
 import com.estime.room.presentation.dto.response.ParticipantVotesResponse;
 import com.estime.room.presentation.dto.response.ParticipantVotesUpdateResponse;
 import com.estime.room.presentation.dto.response.RoomCreateResponse;
@@ -70,22 +68,12 @@ public class RoomController implements RoomControllerSpecification {
     }
 
     @Override
-    public CustomApiResponse<ParticipantCreateResponse> createParticipant(
+    public CustomApiResponse<ParticipantCheckResponse> createParticipant(
             @PathVariable("session") final String session,
             @RequestBody final ParticipantCreateRequest request
     ) {
-        final ParticipantCreateOutput output = roomApplicationService.saveParticipant(
+        final ParticipantCheckOutput output = roomApplicationService.saveParticipant(
                 request.toInput(session));
-        return CustomApiResponse.ok(ParticipantCreateResponse.from(output));
-    }
-
-    @Override
-    public CustomApiResponse<ParticipantCheckResponse> checkParticipantExists(
-            @PathVariable("session") final String session,
-            @RequestParam("participantName") final String participantName
-    ) {
-        final ParticipantCheckOutput output = roomApplicationService.checkParticipantExists(
-                session, participantName);
         return CustomApiResponse.ok(ParticipantCheckResponse.from(output));
     }
 }

--- a/estime-api/src/main/java/com/estime/room/presentation/RoomControllerSpecification.java
+++ b/estime-api/src/main/java/com/estime/room/presentation/RoomControllerSpecification.java
@@ -6,7 +6,6 @@ import com.estime.room.presentation.dto.request.ParticipantVotesUpdateRequest;
 import com.estime.room.presentation.dto.request.RoomCreateRequest;
 import com.estime.room.presentation.dto.response.DateTimeSlotStatisticResponse;
 import com.estime.room.presentation.dto.response.ParticipantCheckResponse;
-import com.estime.room.presentation.dto.response.ParticipantCreateResponse;
 import com.estime.room.presentation.dto.response.ParticipantVotesResponse;
 import com.estime.room.presentation.dto.response.ParticipantVotesUpdateResponse;
 import com.estime.room.presentation.dto.response.RoomCreateResponse;
@@ -57,17 +56,10 @@ public interface RoomControllerSpecification {
             @RequestBody ParticipantVotesUpdateRequest request
     );
 
-    @Operation(summary = "새로운 참여자 생성")
+    @Operation(summary = "새로운 참여자 이름 중복 검증 후 생성")
     @PostMapping("/{session}/participants")
-    CustomApiResponse<ParticipantCreateResponse> createParticipant(
+    CustomApiResponse<ParticipantCheckResponse> createParticipant(
             @PathVariable("session") String session,
             @RequestBody ParticipantCreateRequest request
-    );
-
-    @Operation(summary = "참여자 닉네임 검증")
-    @GetMapping("/{session}/participants")
-    CustomApiResponse<ParticipantCheckResponse> checkParticipantExists(
-            @PathVariable("session") String session,
-            @RequestParam("participantName") String participantName
     );
 }

--- a/estime-api/src/main/java/com/estime/room/presentation/dto/response/ParticipantCheckResponse.java
+++ b/estime-api/src/main/java/com/estime/room/presentation/dto/response/ParticipantCheckResponse.java
@@ -5,9 +5,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record ParticipantCheckResponse(
         @Schema(example = "true")
-        boolean exists
+        boolean isDuplicateName
 ) {
     public static ParticipantCheckResponse from(final ParticipantCheckOutput output) {
-        return new ParticipantCheckResponse(output.exists());
+        return new ParticipantCheckResponse(output.isDuplicateName());
     }
 }

--- a/estime-api/src/test/java/com/estime/room/application/service/RoomApplicationServiceTest.java
+++ b/estime-api/src/test/java/com/estime/room/application/service/RoomApplicationServiceTest.java
@@ -159,11 +159,11 @@ class RoomApplicationServiceTest {
         System.out.println(participant);
 
         // when
-        final ParticipantCheckOutput output = roomApplicationService.checkParticipantExists(
-                room.getSession(), "강산");
+        final ParticipantCheckOutput output = roomApplicationService.saveParticipant(
+                new ParticipantCreateInput(room.getSession(), "강산"));
 
         // then
-        assertThat(output.exists()).isTrue();
+        assertThat(output.isDuplicateName()).isTrue();
     }
 
     @DisplayName("하나의 방에 중복된 이름의 참여자를 만들 수 없다.")
@@ -190,10 +190,8 @@ class RoomApplicationServiceTest {
 
         // when
         // then
-        assertThatThrownBy(() -> roomApplicationService.saveParticipant(
-                new ParticipantCreateInput(room.getSession(), "강산")))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Participant name already exists: 강산");
+        assertThat(roomApplicationService.saveParticipant(
+                new ParticipantCreateInput(room.getSession(), "강산")).isDuplicateName()).isTrue();
     }
 
     private boolean isValidTsid(final String tsid) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #326 

## 📝 작업 내용
참여자 닉네임 중복 검증 API와 생성 API를 통합했습니다. 이외에도 로직과 응답 객체의 변수명을 개선했습니다.

