### PR TITLE
cloudwatch 설정 로직 수정 및 추가

### DIFF
--- a/estime-api/build.gradle
+++ b/estime-api/build.gradle
@@ -24,9 +24,9 @@ dependencies {
 
     implementation 'com.github.f4b6a3:tsid-creator:5.2.6' // for Tsid generation
 
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
-
+    implementation 'org.springframework.boot:spring-boot-starter-actuator' // for monitoring
     implementation 'io.micrometer:micrometer-registry-cloudwatch2'
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-metrics:3.4.0'
 }
 
 tasks.named('test') {

--- a/estime-api/src/main/java/com/estime/aws/CloudWatchUtil.java
+++ b/estime-api/src/main/java/com/estime/aws/CloudWatchUtil.java
@@ -1,0 +1,36 @@
+package com.estime.aws;
+
+import io.micrometer.cloudwatch2.CloudWatchConfig;
+import io.micrometer.cloudwatch2.CloudWatchMeterRegistry;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
+
+@Component
+public class CloudWatchUtil {
+
+    @Bean
+    public MeterRegistry meterRegistry() {
+
+        final CloudWatchAsyncClient cloudWatchClient = CloudWatchAsyncClient.builder()
+                .region(Region.AP_NORTHEAST_2)
+                .build();
+        final CloudWatchConfig cloudWatchConfig = new CloudWatchConfig() {
+
+            @Override
+            public String get(final String key) {
+                return null;
+            }
+
+            @Override
+            public String namespace() {
+                return "EC2/estime-api/dev";
+            }
+        };
+
+        return new CloudWatchMeterRegistry(cloudWatchConfig, Clock.SYSTEM, cloudWatchClient);
+    }
+}

--- a/estime-api/src/main/resources/application.yml
+++ b/estime-api/src/main/resources/application.yml
@@ -50,6 +50,9 @@ management:
       exposure:
         include: "health, info, metrics"
   metrics:
+    enable:
+      all: false
+      http.server.requests: true
     export:
       cloudwatch:
         namespace: "EC2/estime-api/dev"


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #309

## 📝 작업 내용

cloudwatch에서 지표 검색에 namespace가 노출되지 않는 문제를 해결하였습니다.

### 문제 상황
gradle 의존성 추가 및 application.yml 에 관련 설정을 추가했었으나, cloudwatch에서 인식되지 않는 문제 발생

### 어떻게 해결할 것인가?

- cloudwatch registry bean 등록 로직 추가
- spring cloud aws starter metrics 의존성 추가

## 💬 리뷰 요구사항
의존성과 설정만 수정되다 보니 변경사항이 많이 없으나, 새로운 클래스(CloudWatchUtil.class)가 추가되었는데 해당 클래스의 패키지명과 변수명 등 이름이 적절한지 확인해주시면 감사하겠습니다!!

### CloudWatchUtil 이란?
spring actuator를 활용한 micrometer를 사용하고 있습니다. (이에 대한 설명은 길어질 것 같아 추후에 wiki에 정리하겠습니다. 대략적으로 "**spring에서 cloudwatch와 같은 모니터링 도구로 api 속도 측정과 같은 지표를 보낼 수 있구나**"정도로 이해해주시면 됩니다.)

여기서 MeterRegistry를 명시적으로 생성하는 방법을 사용해야 한다고 해서 MeterRegistry를 bean으로 등록하는 클래스입니다.

- CloudWatchUtil: Micrometer의 MeterRegistry 빈을 만들어 CloudWatch 전송을 자동화
- CloudWatchConfig: 메트릭 네임스페이스 포함 각종 전송 설정 제공
- CloudWatchMeterRegistry: 수집된 메트릭을 주기적으로 AWS CloudWatch에 비동기 전송
