### PR TITLE
닉네임 중복 여부 구분 모달 추가

### DIFF
--- a/frontend/src/apis/room/room.ts
+++ b/frontend/src/apis/room/room.ts
@@ -4,7 +4,7 @@ import type {
   CreateRoomResponseType,
   CreateRoomRequestType,
   GetRoomInfoResponseType,
-  CreateUserType,
+  CreateUserRequestType,
   CreateUserResponseType,
   CreateChannelRoomRequestType,
   GetRoomStatisticsResponseType,
@@ -22,7 +22,7 @@ export const createChannelRoom = async (
 
 export const joinUser = async (
   sessionId: string,
-  body: CreateUserType
+  body: CreateUserRequestType
 ): Promise<CreateUserResponseType> => {
   return await api.post(`${ROOM_API_PATH}/${sessionId}/participants`, body);
 };
@@ -35,5 +35,4 @@ export const getRoomStatistics = async (
   sessionId: string
 ): Promise<GetRoomStatisticsResponseType> => {
   return await api.get(`${ROOM_API_PATH}/${sessionId}/statistics/date-time-slots`);
-
 };

--- a/frontend/src/apis/room/type.ts
+++ b/frontend/src/apis/room/type.ts
@@ -21,11 +21,11 @@ export interface GetRoomInfoResponseType {
   deadline: string;
   roomSession: string;
 }
-export interface CreateUserType {
+export interface CreateUserRequestType {
   participantName: string;
 }
 export interface CreateUserResponseType {
-  participantName: string;
+  isDuplicateName: boolean;
 }
 
 export type StatisticItem = {

--- a/frontend/src/apis/time/type.ts
+++ b/frontend/src/apis/time/type.ts
@@ -3,13 +3,9 @@ export interface UserAvailableTimeRequestType {
   dateTimeSlots: string[];
 }
 
-type UserAvailableTimeInnerType = {
-  participantName: string;
-  dateTimeSlots: string;
-};
-
 export type UserAvailableTimeResponseType = {
-  dateTimeSlots: UserAvailableTimeInnerType[];
+  participantName: string;
+  dateTimeSlots: string[];
 };
 
 export interface CombinedAvailableTimesResponseType {

--- a/frontend/src/components/EntryConfirmModal/EntryConfirmModal.styled.ts
+++ b/frontend/src/components/EntryConfirmModal/EntryConfirmModal.styled.ts
@@ -1,0 +1,10 @@
+import styled from '@emotion/styled';
+import Modal from '@/components/Modal';
+
+export const EntryConfirmModalContainer = styled(Modal.Container)`
+  padding: var(--padding-8);
+`;
+
+export const EntryConfirmModalHeader = styled(Modal.Header)`
+  margin-bottom: 12px;
+`;

--- a/frontend/src/components/EntryConfirmModal/EntryConfirmModal.styled.ts
+++ b/frontend/src/components/EntryConfirmModal/EntryConfirmModal.styled.ts
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import Modal from '@/components/Modal';
 
 export const EntryConfirmModalContainer = styled(Modal.Container)`
-  padding: var(--padding-8);
+  padding: var(--padding-10);
 `;
 
 export const EntryConfirmModalHeader = styled(Modal.Header)`

--- a/frontend/src/components/EntryConfirmModal/EntryConfirmModal.styled.ts
+++ b/frontend/src/components/EntryConfirmModal/EntryConfirmModal.styled.ts
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import Modal from '@/components/Modal';
 
 export const EntryConfirmModalContainer = styled(Modal.Container)`
-  padding: var(--padding-10);
+  padding: var(--padding-9) var(--padding-8);
 `;
 
 export const EntryConfirmModalHeader = styled(Modal.Header)`

--- a/frontend/src/components/EntryConfirmModal/index.tsx
+++ b/frontend/src/components/EntryConfirmModal/index.tsx
@@ -1,0 +1,68 @@
+import Modal from '@/components/Modal';
+import Text from '@/components/Text';
+import IInfo from '@/icons/IInfo';
+import Flex from '@/components/Layout/Flex';
+import Button from '@/components/Button';
+import * as S from './EntryConfirmModal.styled';
+import Tooltip from '@/components/Tooltip';
+import { useTheme } from '@emotion/react';
+
+export interface EntryConfirmModalProps {
+  isEntryConfirmModalOpen: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+export const EntryConfirmModal = ({
+  isEntryConfirmModalOpen,
+  onConfirm,
+  onCancel,
+}: EntryConfirmModalProps) => {
+  const theme = useTheme();
+
+  return (
+    <Modal isOpen={isEntryConfirmModalOpen} onClose={onCancel} position="center">
+      <S.EntryConfirmModalContainer>
+        <Modal.Content>
+          <S.EntryConfirmModalHeader>
+            <Flex justify="space-between" align="center" gap="var(--gap-2)">
+              <Tooltip content="서비스를 이용하기 위해 로그인이 필요합니다.">
+                <Flex align="center" gap="var(--gap-4)">
+                  <Text variant="h3">로그인</Text>
+                  <IInfo aria-hidden="true" color={theme.colors.text} />
+                </Flex>
+              </Tooltip>
+            </Flex>
+          </S.EntryConfirmModalHeader>
+
+          <Flex gap="var(--gap-6)" direction="column">
+            <Flex align="center" justify="center" gap="var(--gap-6)">
+              <Flex.Item flex={4}>
+                <Flex direction="column" gap="var(--gap-4)">
+                  <Text variant="body">이미 시간표가 등록되어 있는 닉네임입니다.</Text>
+                  <Text variant="body">이어서 수정하시겠습니까?</Text>
+                </Flex>
+              </Flex.Item>
+            </Flex>
+
+            <Flex.Item flex={1}>
+              <Flex direction="row">
+                <Button color={'plum40'} onClick={onConfirm} data-ga-id="submit-button">
+                  <Text variant="button" color="background">
+                    예
+                  </Text>
+                </Button>
+                <Button color={'primary'} onClick={onCancel}>
+                  <Text variant="button" color="background">
+                    아니오
+                  </Text>
+                </Button>
+              </Flex>
+            </Flex.Item>
+          </Flex>
+        </Modal.Content>
+      </S.EntryConfirmModalContainer>
+    </Modal>
+  );
+};
+
+export default EntryConfirmModal;

--- a/frontend/src/components/EntryConfirmModal/index.tsx
+++ b/frontend/src/components/EntryConfirmModal/index.tsx
@@ -45,14 +45,19 @@ export const EntryConfirmModal = ({
             </Flex>
 
             <Flex.Item flex={1}>
-              <Flex direction="row">
-                <Button color={'plum40'} onClick={onConfirm} data-ga-id="submit-button">
-                  <Text variant="button" color="background">
+              <Flex direction="row" gap="var(--gap-4)">
+                <Button
+                  color={'primary'}
+                  selected={true}
+                  onClick={onConfirm}
+                  data-ga-id="submit-button"
+                >
+                  <Text variant="button" color="gray10">
                     예
                   </Text>
                 </Button>
                 <Button color={'primary'} onClick={onCancel}>
-                  <Text variant="button" color="background">
+                  <Text variant="button" color="primary">
                     아니오
                   </Text>
                 </Button>

--- a/frontend/src/components/EntryConfirmModal/index.tsx
+++ b/frontend/src/components/EntryConfirmModal/index.tsx
@@ -27,7 +27,7 @@ export const EntryConfirmModal = ({
             <Flex justify="space-between" align="center" gap="var(--gap-2)">
               <Tooltip content="서비스를 이용하기 위해 로그인이 필요합니다.">
                 <Flex align="center" gap="var(--gap-4)">
-                  <Text variant="h3">로그인</Text>
+                  <Text variant="h3">정보 입력</Text>
                   <IInfo aria-hidden="true" color={theme.colors.text} />
                 </Flex>
               </Tooltip>

--- a/frontend/src/components/EntryConfirmModal/index.tsx
+++ b/frontend/src/components/EntryConfirmModal/index.tsx
@@ -46,12 +46,7 @@ export const EntryConfirmModal = ({
 
             <Flex.Item flex={1}>
               <Flex direction="row" gap="var(--gap-4)">
-                <Button
-                  color={'primary'}
-                  selected={true}
-                  onClick={onConfirm}
-                  data-ga-id="submit-button"
-                >
+                <Button color={'primary'} selected={true} onClick={onConfirm}>
                   <Text variant="button" color="gray10">
                     예
                   </Text>

--- a/frontend/src/components/EntryConfirmModal/index.tsx
+++ b/frontend/src/components/EntryConfirmModal/index.tsx
@@ -34,12 +34,12 @@ export const EntryConfirmModal = ({
             </Flex>
           </S.EntryConfirmModalHeader>
 
-          <Flex gap="var(--gap-6)" direction="column">
+          <Flex gap="var(--gap-7)" direction="column">
             <Flex align="center" justify="center" gap="var(--gap-6)">
-              <Flex.Item flex={4}>
-                <Flex direction="column" gap="var(--gap-4)">
-                  <Text variant="body">이미 시간표가 등록되어 있는 닉네임입니다.</Text>
-                  <Text variant="body">이어서 수정하시겠습니까?</Text>
+              <Flex.Item flex={5}>
+                <Flex direction="column" gap="var(--gap-6)">
+                  <Text variant="h4">이미 시간표가 등록되어 있는 닉네임입니다.</Text>
+                  <Text variant="h4">이어서 수정하시겠습니까?</Text>
                 </Flex>
               </Flex.Item>
             </Flex>

--- a/frontend/src/components/LoginModal/LoginModal.stories.tsx
+++ b/frontend/src/components/LoginModal/LoginModal.stories.tsx
@@ -47,7 +47,7 @@ export const Default: Story = {
           isLoginModalOpen={isLoginModalOpen}
           handleCloseLoginModal={() => {}}
           handleModalLogin={() => {}}
-          userData={{ name: '', password: '' }}
+          userData={{ name: '' }}
           handleUserData={() => {}}
         />
       </Flex>
@@ -73,7 +73,7 @@ export const PreOpenModal: Story = {
           isLoginModalOpen={isLoginModalOpen}
           handleCloseLoginModal={() => {}}
           handleModalLogin={() => {}}
-          userData={{ name: '', password: '' }}
+          userData={{ name: '' }}
           handleUserData={() => {}}
         />
       </Flex>

--- a/frontend/src/components/LoginModal/index.tsx
+++ b/frontend/src/components/LoginModal/index.tsx
@@ -76,7 +76,7 @@ export const LoginModal = ({
                 data-ga-id="submit-button"
               >
                 <Text variant="button" color="background">
-                  저장하고 계속하기
+                  입장하기
                 </Text>
               </Button>
             </Flex.Item>

--- a/frontend/src/components/Timetable/TimeTableCell/TimeTableCell.styled.ts
+++ b/frontend/src/components/Timetable/TimeTableCell/TimeTableCell.styled.ts
@@ -10,7 +10,8 @@ export const HeaderCell = styled.div<{
   display: flex;
   align-items: center;
   justify-content: center;
-  cursor: pointer;
+  cursor: ${({ isDate }) => (isDate ? 'not-allowed' : 'pointer')};
+  pointer-events: ${({ isDate }) => (isDate ? 'none' : 'inherit')};
   padding: var(--padding-4);
   height: ${({ isDate }) => (isDate ? '3rem' : '1.5rem')};
   width: 100%;

--- a/frontend/src/hooks/Login/useUserLogin.ts
+++ b/frontend/src/hooks/Login/useUserLogin.ts
@@ -4,13 +4,7 @@ import { useRef, useState } from 'react';
 export type LoginData = {
   name: string;
 };
-export function useUserLogin({
-  session,
-  onDuplicateNickname,
-}: {
-  session: string | null;
-  onDuplicateNickname: () => void;
-}) {
+export function useUserLogin({ session }: { session: string | null }) {
   if (!session) {
     throw new Error('Session ID is required for user login');
   }
@@ -26,13 +20,8 @@ export function useUserLogin({
     const response = await joinUser(session, {
       participantName: userData.name,
     });
-
-    if (response.isDuplicateName) {
-      onDuplicateNickname();
-      return true;
-    }
     isLoggedIn.current = true;
-    return false;
+    return response.isDuplicateName;
   };
   const resetUserData = () => setUserData({ name: '' });
   return {

--- a/frontend/src/hooks/Login/useUserLogin.ts
+++ b/frontend/src/hooks/Login/useUserLogin.ts
@@ -9,7 +9,7 @@ export function useUserLogin({
   onDuplicateNickname,
 }: {
   session: string | null;
-  onDuplicateNickname?: () => void;
+  onDuplicateNickname: () => void;
 }) {
   if (!session) {
     throw new Error('Session ID is required for user login');
@@ -28,7 +28,7 @@ export function useUserLogin({
     });
 
     if (response.isDuplicateName) {
-      onDuplicateNickname?.();
+      onDuplicateNickname();
       return true;
     }
     isLoggedIn.current = true;

--- a/frontend/src/hooks/Login/useUserLogin.ts
+++ b/frontend/src/hooks/Login/useUserLogin.ts
@@ -20,9 +20,6 @@ export function useUserLogin({
   const isLoggedIn = useRef(false);
 
   const handleLogin = async (): Promise<boolean> => {
-    if (!session) {
-      throw new Error('세션이 없습니다. 로그인에 실패했습니다.');
-    }
     if (userData.name.trim().length === 0) {
       throw new Error('아이디를 입력해주세요.');
     }

--- a/frontend/src/hooks/TimeTableRoom/useModalControl.ts
+++ b/frontend/src/hooks/TimeTableRoom/useModalControl.ts
@@ -1,11 +1,11 @@
 import { useState } from 'react';
 
-type modalTypeKey = 'login' | 'entryConfirm';
+type modalTypeKey = 'Login' | 'EntryConfirm';
 
 export function useModalControl() {
   const [modals, setModals] = useState<Record<modalTypeKey, boolean>>({
-    login: false,
-    entryConfirm: false,
+    Login: false,
+    EntryConfirm: false,
   });
 
   const handleOpenModal = (key: modalTypeKey) => {

--- a/frontend/src/hooks/TimeTableRoom/useModalControl.ts
+++ b/frontend/src/hooks/TimeTableRoom/useModalControl.ts
@@ -1,18 +1,23 @@
 import { useState } from 'react';
 
-export function useModalControl() {
-  const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
+type modalTypeKey = 'login' | 'entryConfirm';
 
-  const handleOpenLoginModal = () => {
-    setIsLoginModalOpen(true);
+export function useModalControl() {
+  const [modals, setModals] = useState<Record<modalTypeKey, boolean>>({
+    login: false,
+    entryConfirm: false,
+  });
+
+  const handleOpenModal = (key: modalTypeKey) => {
+    setModals((prev) => ({ ...prev, [key]: true }));
   };
-  const handleCloseLoginModal = () => {
-    setIsLoginModalOpen(false);
+  const handleCloseModal = (key: modalTypeKey) => {
+    setModals((prev) => ({ ...prev, [key]: false }));
   };
 
   return {
-    isLoginModalOpen,
-    handleOpenLoginModal,
-    handleCloseLoginModal,
+    modals,
+    handleOpenModal,
+    handleCloseModal,
   };
 }

--- a/frontend/src/hooks/TimeTableRoom/useModalControl.ts
+++ b/frontend/src/hooks/TimeTableRoom/useModalControl.ts
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 
 type modalTypeKey = 'Login' | 'EntryConfirm';
-
+type Modals = Record<modalTypeKey, boolean>;
 export function useModalControl() {
-  const [modals, setModals] = useState<Record<modalTypeKey, boolean>>({
+  const [modals, setModals] = useState<Modals>({
     Login: false,
     EntryConfirm: false,
   });

--- a/frontend/src/hooks/common/useExtractQueryParams.ts
+++ b/frontend/src/hooks/common/useExtractQueryParams.ts
@@ -20,8 +20,10 @@ export const useExtractQueryParams = <T extends string | string[]>(
       acc[key as T[number]] = params.get(key);
       return acc;
     },
+    // as는 좀...
     {} as { [K in T[number]]: string | null }
   );
 
+  // as는 좀...
   return result as QueryParamResult<T>;
 };

--- a/frontend/src/hooks/common/useExtractQueryParams.ts
+++ b/frontend/src/hooks/common/useExtractQueryParams.ts
@@ -20,10 +20,8 @@ export const useExtractQueryParams = <T extends string | string[]>(
       acc[key as T[number]] = params.get(key);
       return acc;
     },
-    // as는 좀...
     {} as { [K in T[number]]: string | null }
   );
 
-  // as는 좀...
   return result as QueryParamResult<T>;
 };

--- a/frontend/src/hooks/useUserAvailability.ts
+++ b/frontend/src/hooks/useUserAvailability.ts
@@ -48,10 +48,9 @@ export const useUserAvailability = ({
     }
     const userAvailableTimeInfo = await getUserAvailableTime(session, name);
     const dateTimeSlotsResponse = userAvailableTimeInfo.dateTimeSlots;
-    const dateTimeSlots = dateTimeSlotsResponse.map((item) => item.dateTimeSlots);
     userName.set(name);
     if (userAvailableTimeInfo.dateTimeSlots.length > 0) {
-      const selectedTimesResponse = new Set(dateTimeSlots);
+      const selectedTimesResponse = new Set(dateTimeSlotsResponse);
       selectedTimes.set(selectedTimesResponse);
     }
   };

--- a/frontend/src/pages/CheckEventPage.tsx
+++ b/frontend/src/pages/CheckEventPage.tsx
@@ -22,7 +22,6 @@ const CheckEventPage = () => {
 
   const { handleLogin, userData, handleUserData, name, isLoggedIn } = useUserLogin({
     session,
-    onDuplicateNickname: () => handleOpenModal('EntryConfirm'),
   });
 
   const { userName, selectedTimes, userAvailabilitySubmit, fetchUserAvailableTime } =
@@ -68,7 +67,9 @@ const CheckEventPage = () => {
   const loginAndLoadSchedulingData = async () => {
     try {
       const isDuplicated = await handleLogin();
+
       if (isDuplicated) {
+        handleOpenModal('EntryConfirm');
         return;
       }
 

--- a/frontend/src/pages/CheckEventPage.tsx
+++ b/frontend/src/pages/CheckEventPage.tsx
@@ -22,7 +22,7 @@ const CheckEventPage = () => {
 
   const { handleLogin, userData, handleUserData, name, isLoggedIn } = useUserLogin({
     session,
-    onDuplicateNickname: () => handleOpenModal('entryConfirm'),
+    onDuplicateNickname: () => handleOpenModal('EntryConfirm'),
   });
 
   const { userName, selectedTimes, userAvailabilitySubmit, fetchUserAvailableTime } =
@@ -57,7 +57,7 @@ const CheckEventPage = () => {
   const handleToggleEditMode = async () => {
     if (mode === 'view') {
       if (isLoggedIn) setMode('edit');
-      else handleOpenModal('login');
+      else handleOpenModal('Login');
     } else {
       await userAvailabilitySubmit();
       await fetchRoomStatistics(session);
@@ -73,7 +73,7 @@ const CheckEventPage = () => {
       }
 
       await fetchUserAvailableTime();
-      handleCloseModal('login');
+      handleCloseModal('Login');
       setMode('edit');
     } catch (err) {
       const e = err as Error;
@@ -85,8 +85,8 @@ const CheckEventPage = () => {
 
   const handleContinueWithDuplicated = async () => {
     try {
-      handleCloseModal('entryConfirm');
-      handleCloseModal('login');
+      handleCloseModal('EntryConfirm');
+      handleCloseModal('Login');
       await fetchUserAvailableTime();
       setMode('edit');
     } catch (err) {
@@ -97,7 +97,7 @@ const CheckEventPage = () => {
   };
 
   const handleCancelContinueWithDuplicated = () => {
-    handleCloseModal('entryConfirm');
+    handleCloseModal('EntryConfirm');
   };
   return (
     <>
@@ -134,14 +134,14 @@ const CheckEventPage = () => {
         </Flex>
       </Wrapper>
       <LoginModal
-        isLoginModalOpen={modals['login']}
-        handleCloseLoginModal={() => handleCloseModal('login')}
+        isLoginModalOpen={modals['Login']}
+        handleCloseLoginModal={() => handleCloseModal('Login')}
         handleModalLogin={loginAndLoadSchedulingData}
         userData={userData}
         handleUserData={handleUserData}
       />
       <EntryConfirmModal
-        isEntryConfirmModalOpen={modals['entryConfirm']}
+        isEntryConfirmModalOpen={modals['EntryConfirm']}
         onConfirm={handleContinueWithDuplicated}
         onCancel={handleCancelContinueWithDuplicated}
       />


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #331 

* 로직 변경 사항이 다소 있어 설명 중요도 순으로 작성해 두었습니다 !

## 📝 작업 내용

#### Given 사용자가 닉네임 입력 후 '입장하기' 버튼을 눌렀을 때

#### When (1) 이미 있는 사용자인 경우

#### Then 새로운 모달 - 로그인 모달 위에 띄워져야 한다.

[1] 예 선택 시 (기존 사용자로 계속하겠다)-> 새로운 모달 및 로그인 모달 둘다 닫혀야 한다.
[2] 아니오 선택 시 (새로운 아이디로 입력하겠다)-> 새로운 모달만 닫혀야 한다.

#### When (2) 신규 사용자인 경우

#### Then 새로운 모달은 열리지 않은 채 로그인 모달은 닫혀야 한다.


### 🔥 hotfix: UserAvailableTimeResponseType 수정
데이터 구조 변경에 따라 잘못 맵핑하고 있어서 발생한 문제

(1) 타입 수정
```tsx
export type UserAvailableTimeResponseType = {
  participantName: string;
  dateTimeSlots: string[];
};
```

(2) map 로직 제거
기존에는 response.dataTimeSlots 에서 item => item.dateTimeSlots로 map을 돌고 있었는데 이과정에서 undefined로 맵핑되어 기존에 사용자가 제출한 시간표도 UI에 그려지지 않고 있었습니둥

### useModalControl 수정
- useModalControl의 경우 현재 로그인 모달만 대응하도록 되어 있어서 핸들러 함수에 key값을 전달하여 각 모달들의 open 상태를 관리하도록 해 두었습니다.

```tsx

type modalTypeKey = 'login' | 'entryConfirm';

export function useModalControl() {
  const [modals, setModals] = useState<Record<modalTypeKey, boolean>>({
    login: false,
    entryConfirm: false,
  });
....
```

## 💬 리뷰 요구사항

### CheckEventPage 고민

보시면 아시다시피 모달들에 props로 핸들러 함수를 넘겨주려다 보니,, handle~~ 함수가 꽤나 많이 위치하고 있는데 페이지 단에서 너무 많은 로직을 가지고 있는게 아닌가 싶은 생각이 듭니다,, 우선 hotfix 건도 있고 하여 로직을 페이지 단에 두었습니다 이 부분 같이 고민해주심 감사하겠습니다 ! (큰 규모의 리팩토링이라면 4차 데모 전에 고치는 방법도 좋을 것 같아요!)