### PR TITLE
Timetable, Heatmap 플립 애니메이션 추가

### DIFF
--- a/frontend/src/pages/CheckEventPage.tsx
+++ b/frontend/src/pages/CheckEventPage.tsx
@@ -108,29 +108,44 @@ const CheckEventPage = () => {
             title={roomInfo.title}
             roomSession={roomInfo.roomSession}
           />
+          <S.FlipCard isFlipped={mode !== 'view'}>
+            {/* view 모드 */}
+            <S.FrontFace isFlipped={mode !== 'view'}>
+              <S.TimeTableContainer>
+                <Flex direction="column" gap="var(--gap-8)">
+                  <TimeTableHeader
+                    name={roomInfo.title}
+                    mode={mode}
+                    onToggleEditMode={handleToggleEditMode}
+                  />
+                  <Heatmap
+                    dateTimeSlots={roomInfo.availableTimeSlots}
+                    availableDates={roomInfo.availableDateSlots}
+                    roomStatistics={roomStatistics}
+                  />
+                </Flex>
+              </S.TimeTableContainer>
+            </S.FrontFace>
 
-          <S.TimeTableContainer>
-            <Flex direction="column" gap="var(--gap-8)">
-              <TimeTableHeader
-                name={mode === 'view' ? roomInfo.title : userName.value}
-                mode={mode}
-                onToggleEditMode={handleToggleEditMode}
-              />
-              {mode === 'view' ? (
-                <Heatmap
-                  dateTimeSlots={roomInfo.availableTimeSlots}
-                  availableDates={roomInfo.availableDateSlots}
-                  roomStatistics={roomStatistics}
-                />
-              ) : (
-                <Timetable
-                  dateTimeSlots={roomInfo.availableTimeSlots}
-                  availableDates={roomInfo.availableDateSlots}
-                  selectedTimes={selectedTimes}
-                />
-              )}
-            </Flex>
-          </S.TimeTableContainer>
+            {/* edit 모드 */}
+            <S.BackFace isFlipped={mode !== 'view'}>
+              <S.TimeTableContainer>
+                <Flex direction="column" gap="var(--gap-8)">
+                  <TimeTableHeader
+                    name={userName.value}
+                    mode={mode}
+                    onToggleEditMode={handleToggleEditMode}
+                  />
+
+                  <Timetable
+                    dateTimeSlots={roomInfo.availableTimeSlots}
+                    availableDates={roomInfo.availableDateSlots}
+                    selectedTimes={selectedTimes}
+                  />
+                </Flex>
+              </S.TimeTableContainer>
+            </S.BackFace>
+          </S.FlipCard>
         </Flex>
       </Wrapper>
       <LoginModal

--- a/frontend/src/pages/styles/CheckEventPage.styled.ts
+++ b/frontend/src/pages/styles/CheckEventPage.styled.ts
@@ -8,11 +8,6 @@ export const TimeTableContainer = styled.div`
   box-shadow: var(--shadow-card);
 `;
 
-export const FlipCardWrapper = styled.div`
-  position: relative;
-  width: 100%;
-`;
-
 export const FlipCard = styled.div<{ isFlipped: boolean }>`
   position: relative;
   width: 100%;

--- a/frontend/src/pages/styles/CheckEventPage.styled.ts
+++ b/frontend/src/pages/styles/CheckEventPage.styled.ts
@@ -7,3 +7,35 @@ export const TimeTableContainer = styled.div`
   border-radius: var(--radius-4);
   box-shadow: var(--shadow-card);
 `;
+
+export const FlipCardWrapper = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
+export const FlipCard = styled.div<{ isFlipped: boolean }>`
+  position: relative;
+  width: 100%;
+  transition: transform 1s ease;
+  transform-style: preserve-3d;
+  transform: ${({ isFlipped }) => (isFlipped ? 'rotateY(180deg)' : 'none')};
+`;
+
+export const FlipFace = styled.div`
+  backface-visibility: hidden;
+  width: 100%;
+`;
+
+export const FrontFace = styled(FlipFace)<{ isFlipped: boolean }>`
+  z-index: ${({ isFlipped }) => (isFlipped ? 1 : 2)};
+  pointer-events: ${({ isFlipped }) => (isFlipped ? 'none' : 'auto')};
+`;
+
+export const BackFace = styled(FlipFace)<{ isFlipped: boolean }>`
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: rotateY(180deg);
+  z-index: ${({ isFlipped }) => (isFlipped ? 2 : 1)};
+  pointer-events: ${({ isFlipped }) => (isFlipped ? 'auto' : 'none')};
+`;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #348 

## 📝 작업 내용

- 타임테이블과 히트맵 전환 시에 rotateY로 뒤집는 애니메이션 구현

## 💬 리뷰 요구사항

### 트러블 슈팅

* 참고

FrontFace: 히트맵
BackFace: 시간표 등록

🔥 FrontFace와 BackFace 모두 absolute를 주었더니 상위 요소인 FlipCard에서 높이를 잡지 못해 0이되는 문제
** position:absolute일 때는 부모 요소가 자식요소의 높이를 측정하지 못함

=> 화면을 보았을 떄 높이가 깨져보임

-> 처음 해결 방법 : BackFace에만 position: absolute를 줌

🔥 BackFace 에서 시간표 등록할 때 '저장하기' 버튼이 안 눌림

-> 해결 방법 : 둘 다 absolute를 주되 isFlipped 상태에 따라 pointer-events, z-index 조절

