### PR TITLE
HTTP 요청/응답 로깅 필터 추가

### DIFF
--- a/.github/workflows/CD-dev.yml
+++ b/.github/workflows/CD-dev.yml
@@ -82,7 +82,7 @@ jobs:
             ${{ secrets.DEV_IMAGE_NAME }}:latest
 
   deploy:
-    runs-on: self-hosted
+    runs-on: [ self-hosted, estime-dev ]
     needs: build-and-push
 
     env:

--- a/.github/workflows/CD-prod.yml
+++ b/.github/workflows/CD-prod.yml
@@ -82,7 +82,7 @@ jobs:
             ${{ secrets.PROD_IMAGE_NAME }}:latest
 
   deploy:
-    runs-on: self-hosted
+    runs-on: [ self-hosted, estime-prod ]
     needs: build-and-push
 
     env:

--- a/estime-api/src/main/java/com/estime/common/logging/ApiLogFilter.java
+++ b/estime-api/src/main/java/com/estime/common/logging/ApiLogFilter.java
@@ -1,0 +1,85 @@
+package com.estime.common.logging;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class ApiLogFilter implements Filter {
+
+    private static final String TRACE_ID_KEY = "traceId";
+
+    @Override
+    public void doFilter(final ServletRequest servletRequest, final ServletResponse servletResponse,
+                         final FilterChain filterChain) throws IOException, ServletException {
+        final HttpServletRequest request = (HttpServletRequest) servletRequest;
+        final HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+        final String traceId = generateTraceId();
+        MDC.put(TRACE_ID_KEY, traceId);
+
+        final long startTime = System.currentTimeMillis();
+        logRequest(request);
+
+        try {
+            filterChain.doFilter(servletRequest, servletResponse);
+            logResponse(response, startTime);
+        } catch (final Exception ex) {
+            logError(request, ex, startTime);
+            throw ex;
+        } finally {
+            MDC.clear();
+        }
+    }
+
+    private void logRequest(final HttpServletRequest request) {
+        final String uri = request.getRequestURI();
+        final String method = request.getMethod();
+        final String ip = request.getRemoteAddr();
+        final String query = request.getQueryString();
+        final String userAgent = request.getHeader("User-Agent");
+
+        log.info("[REQ] layer=filter | ip={} | method={} | uri={}{} | ua={}",
+                ip, method, uri,
+                (query != null ? "?" + query : ""),
+                (userAgent != null ? userAgent : "-")
+        );
+    }
+
+    private void logResponse(final HttpServletResponse response, final long startTime) {
+        final long duration = System.currentTimeMillis() - startTime;
+        final int status = response.getStatus();
+        final String contentType = response.getContentType();
+        final int contentLength = response.getBufferSize();
+
+        log.info("[RES] layer=filter | status={} | duration={}ms | contentType={} | length={}",
+                status, duration,
+                (contentType != null ? contentType : "-"),
+                (contentLength > 0 ? contentLength + "B" : "-")
+        );
+    }
+
+    private void logError(final HttpServletRequest request, final Exception ex, final long startTime) {
+        final long duration = System.currentTimeMillis() - startTime;
+        final String uri = request.getRequestURI();
+        final String method = request.getMethod();
+        final int status = 500;
+
+        log.error("[ERR] layer=filter | method={} | uri={} | duration={}ms | status={} | error={}",
+                method, uri, duration, status, ex.toString(), ex);
+    }
+
+    private String generateTraceId() {
+        return UUID.randomUUID().toString().substring(0, 8);
+    }
+}

--- a/estime-api/src/main/java/com/estime/common/logging/ApiLogFilter.java
+++ b/estime-api/src/main/java/com/estime/common/logging/ApiLogFilter.java
@@ -8,6 +8,7 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Component;
 public class ApiLogFilter implements Filter {
 
     private static final String TRACE_ID_KEY = "traceId";
+    private static final String REQUEST_ID_HEADER = "X-Request-Id";
 
     @Override
     public void doFilter(final ServletRequest servletRequest, final ServletResponse servletResponse,
@@ -25,19 +27,25 @@ public class ApiLogFilter implements Filter {
         final HttpServletRequest request = (HttpServletRequest) servletRequest;
         final HttpServletResponse response = (HttpServletResponse) servletResponse;
 
-        final String traceId = generateTraceId();
+        final String traceId = Optional.ofNullable(request.getHeader(REQUEST_ID_HEADER))
+                .filter(s -> !s.isBlank())
+                .orElseGet(this::generateTraceId);
+
         MDC.put(TRACE_ID_KEY, traceId);
+        response.setHeader(REQUEST_ID_HEADER, traceId);
 
         final long startTime = System.currentTimeMillis();
         logRequest(request);
 
+        int statusForLog = 200;
         try {
             filterChain.doFilter(servletRequest, servletResponse);
-            logResponse(response, startTime);
+            statusForLog = response.getStatus();
         } catch (final Exception ex) {
-            logError(request, ex, startTime);
+            statusForLog = 500;
             throw ex;
         } finally {
+            logResponse(response, startTime, statusForLog);
             MDC.clear();
         }
     }
@@ -46,37 +54,20 @@ public class ApiLogFilter implements Filter {
         final String uri = request.getRequestURI();
         final String method = request.getMethod();
         final String ip = request.getRemoteAddr();
-        final String query = request.getQueryString();
-        final String userAgent = request.getHeader("User-Agent");
 
-        log.info("[REQ] layer=filter | ip={} | method={} | uri={}{} | ua={}",
-                ip, method, uri,
-                (query != null ? "?" + query : ""),
-                (userAgent != null ? userAgent : "-")
-        );
+        final String queryString = request.getQueryString();
+        final String userAgentHeader = request.getHeader("User-Agent");
+        final String query = (queryString != null ? "?" + queryString : "");
+        final String userAgent = (userAgentHeader != null ? userAgentHeader : "-");
+
+        log.info("[REQ] layer=filter | ip={} | method={} | uri={}{} | ua={}", ip, method, uri, query, userAgent);
     }
 
-    private void logResponse(final HttpServletResponse response, final long startTime) {
+    private void logResponse(final HttpServletResponse response, final long startTime, final int status) {
         final long duration = System.currentTimeMillis() - startTime;
-        final int status = response.getStatus();
-        final String contentType = response.getContentType();
-        final int contentLength = response.getBufferSize();
+        final String contentType = Optional.ofNullable(response.getContentType()).orElse("-");
 
-        log.info("[RES] layer=filter | status={} | duration={}ms | contentType={} | length={}",
-                status, duration,
-                (contentType != null ? contentType : "-"),
-                (contentLength > 0 ? contentLength + "B" : "-")
-        );
-    }
-
-    private void logError(final HttpServletRequest request, final Exception ex, final long startTime) {
-        final long duration = System.currentTimeMillis() - startTime;
-        final String uri = request.getRequestURI();
-        final String method = request.getMethod();
-        final int status = 500;
-
-        log.error("[ERR] layer=filter | method={} | uri={} | duration={}ms | status={} | error={}",
-                method, uri, duration, status, ex.toString(), ex);
+        log.info("[RES] layer=filter | status={} | duration={}ms | contentType={}", status, duration, contentType);
     }
 
     private String generateTraceId() {

--- a/estime-api/src/main/resources/application-common.yml
+++ b/estime-api/src/main/resources/application-common.yml
@@ -7,10 +7,6 @@ spring:
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}
 
-springdoc:
-  swagger-ui:
-    path: /docs
-
 server:
   forward-headers-strategy: framework
 

--- a/estime-api/src/main/resources/application-dev.yml
+++ b/estime-api/src/main/resources/application-dev.yml
@@ -16,7 +16,11 @@ spring:
     database-platform: org.hibernate.dialect.MySQL8Dialect
 
   flyway:
-    baseline-on-migrate: true
+    enabled: true
+
+springdoc:
+  swagger-ui:
+    path: /docs
 
 logging:
   file:

--- a/estime-api/src/main/resources/application-local.yml
+++ b/estime-api/src/main/resources/application-local.yml
@@ -15,6 +15,13 @@ spring:
         format_sql: true
     database-platform: org.hibernate.dialect.MySQL8Dialect
 
+  flyway:
+    enabled: true
+
+springdoc:
+  swagger-ui:
+    path: /docs
+
 logging:
   level:
     root: INFO

--- a/estime-api/src/main/resources/application-prod.yml
+++ b/estime-api/src/main/resources/application-prod.yml
@@ -11,6 +11,9 @@ spring:
       ddl-auto: validate
     database-platform: org.hibernate.dialect.MySQL8Dialect
 
+  flyway:
+    enabled: true
+
 logging:
   file:
     name: /app/logs/estime-api.log


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #327

## 📝 작업 내용

### ApiLogFilter 추가

- 요청/응답/에러 로깅 필터 구현
- 로그
  - [REQ] 요청 로그: IP, HTTP 메서드, URI, 쿼리스트링, User-Agent 기록
  - [RES] 응답 로그: 상태 코드, 처리 시간(ms), Content-Type, 응답 길이(bufferSize) 기록
  - [ERR] 예외 로그: HTTP 메서드, URI, 처리 시간(ms), 상태 코드(500), 예외 정보 기록
     ```
    [REQ] layer=filter | ip=203.0.113.10 | method=GET | uri=/api/rooms?size=20 | ua=curl/8.7.1
    [RES] layer=filter | status=200 | duration=23ms | contentType=application/json | length=-
    [ERR] layer=filter | method=POST | uri=/api/rooms | duration=12ms | status=500 | error=java.lang.IllegalStateException: ...
    ```

### traceId 기반 요청 추적

- 요청 시작 시 UUID 기반 traceId 생성 후 MDC에 저장
- traceId는 UUID 앞 8자리만 사용
- 모든 요청 흐름에서 동일한 traceId가 로그에 포함되어 요청 단위 추적 가능

### 기타

- 요청 처리 완료 후 MDC.clear() 호출로 traceId 누수 방지
- 로그 패턴에 %X{traceId} 추가 시 모든 로그에서 traceId 자동 출력 가능

## 💬 리뷰 요구사항

요청/응답/예외 상황별로 수집하는 로깅 정보(IP, 메서드, URI, 상태 코드, 처리 시간 등)가 충분하고 적절한지 검토 부탁드립니다.
