### PR TITLE
dev, prod 환경 설정 수정

### DIFF
--- a/.github/workflows/CD-dev.yml
+++ b/.github/workflows/CD-dev.yml
@@ -82,7 +82,7 @@ jobs:
             ${{ secrets.DEV_IMAGE_NAME }}:latest
 
   deploy:
-    runs-on: self-hosted
+    runs-on: [ self-hosted, estime-dev ]
     needs: build-and-push
 
     env:

--- a/.github/workflows/CD-prod.yml
+++ b/.github/workflows/CD-prod.yml
@@ -82,7 +82,7 @@ jobs:
             ${{ secrets.PROD_IMAGE_NAME }}:latest
 
   deploy:
-    runs-on: self-hosted
+    runs-on: [ self-hosted, estime-prod ]
     needs: build-and-push
 
     env:

--- a/estime-api/src/main/resources/application-common.yml
+++ b/estime-api/src/main/resources/application-common.yml
@@ -7,10 +7,6 @@ spring:
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}
 
-springdoc:
-  swagger-ui:
-    path: /docs
-
 server:
   forward-headers-strategy: framework
 

--- a/estime-api/src/main/resources/application-dev.yml
+++ b/estime-api/src/main/resources/application-dev.yml
@@ -16,7 +16,11 @@ spring:
     database-platform: org.hibernate.dialect.MySQL8Dialect
 
   flyway:
-    baseline-on-migrate: true
+    enabled: true
+
+springdoc:
+  swagger-ui:
+    path: /docs
 
 logging:
   file:

--- a/estime-api/src/main/resources/application-local.yml
+++ b/estime-api/src/main/resources/application-local.yml
@@ -15,6 +15,13 @@ spring:
         format_sql: true
     database-platform: org.hibernate.dialect.MySQL8Dialect
 
+  flyway:
+    enabled: true
+
+springdoc:
+  swagger-ui:
+    path: /docs
+
 logging:
   level:
     root: INFO

--- a/estime-api/src/main/resources/application-prod.yml
+++ b/estime-api/src/main/resources/application-prod.yml
@@ -11,6 +11,9 @@ spring:
       ddl-auto: validate
     database-platform: org.hibernate.dialect.MySQL8Dialect
 
+  flyway:
+    enabled: true
+
 logging:
   file:
     name: /app/logs/estime-api.log


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #370 

## 📝 작업 내용

self-hosted-runner 구분이 되지 않는 문제를 해결하였습니다.

estime-dev와 estime-prod 로 2개의 runner를 구성하고 있는 상황에서 각 cd.yml에는 아래와 같이 구성되어 있었습니다.

```yaml
  deploy:
    runs-on: self-hosted
    needs: build-and-push
```

runs-on에는 runner의 tag를 작성하는 방식입니다. 여기서 두 runner의 태그로 `self-hosted`가 있기 때문에 둘 중 먼저 연결된 runner에 cd 과정이 실행되는 문제가 있습니다.

---

```yaml
  deploy:
    runs-on: [ self-hosted, estime-prod ]
    needs: build-and-push

```

따라서 위 형태로 특정 runner를 인식할 수 있는 tag를 각각 estime-dev, estime-prod로 추가하여 두 runner를 분리하여 인식할 수 있도록 재구성하였습니다.

---

### local, dev, prod 프로퍼티 수정

- swagger 접근 경로 local, dev에만 공개
- flyway 사용 여부 설정 명시

## 💬 리뷰 요구사항
