### PR TITLE
prod용 docker-compose api 컨테이너의 mysql 컨테이너 의존성 잔류 코드 제거

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,8 +1,6 @@
 services:
   api:
     container_name: estime-api
-    depends_on:
-      - mysql
     image: ${IMAGE_NAME}:${IMAGE_TAG:-latest}
     env_file:
       - ./estime-api/.env.prod


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #372 

## 📝 작업 내용

docker-compose-prod.yml에 불필요한 dev 용 compose 코드가 남아있던 문제를 해결하였습니다.

- mysql 컨테이너 의존성 잔류 코드 제거

## 💬 리뷰 요구사항
제가 놓친 문제 사항이 있다면 말씀해주시면 감사하겠습니다!