### PR TITLE
estime-api 컨테이너용 dockerfile 스크립트 수정

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,7 +2,8 @@ services:
   api:
     container_name: estime-api
     depends_on:
-      - mysql
+      mysql:
+        condition: service_healthy
     image: ${IMAGE_NAME}:${IMAGE_TAG:-latest}
     env_file:
       - ./estime-api/.env.dev

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,8 +1,6 @@
 services:
   api:
     container_name: estime-api
-    depends_on:
-      - mysql
     image: ${IMAGE_NAME}:${IMAGE_TAG:-latest}
     env_file:
       - ./estime-api/.env.prod

--- a/estime-api/Dockerfile
+++ b/estime-api/Dockerfile
@@ -1,12 +1,6 @@
 FROM eclipse-temurin:21-jdk-alpine
 
-RUN apk add --no-cache bash curl dos2unix \
-  && curl -fsSL https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh \
-     -o /usr/local/bin/wait-for-it \
-  && dos2unix /usr/local/bin/wait-for-it \
-  && chmod +x /usr/local/bin/wait-for-it
-
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} /app.jar
 
-ENTRYPOINT ["/usr/bin/env", "bash", "/usr/local/bin/wait-for-it", "mysql:3306", "--timeout=30", "--strict", "--", "java", "-jar", "/app.jar"]
+ENTRYPOINT ["/usr/bin/env", "java", "-jar", "/app.jar"]


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #373 

## 📝 작업 내용

prod에서는 별도의 mysql 서버가 존재하고 있고, dev 환경에서는 docker-compose 옵션을 통해 설정 가능한 것을 확인하여 dev 환경에서 사용하고 있던 wait-for-it.sh 로직을 삭제하였습니다.

- wait-for-it.sh 로직 삭제
- docker-compose.prod.yml api 컨테이너에 mysql 컨테이너 의존 스크립트 삭제

## 💬 리뷰 요구사항
