### PR TITLE
디스코드 서버 에러 로그 구현

### DIFF
--- a/estime-api/build.gradle
+++ b/estime-api/build.gradle
@@ -5,6 +5,11 @@ plugins {
 group = 'com.estime'
 version = '0.0.1-SNAPSHOT'
 
+repositories {
+    mavenCentral()
+    maven { url 'https://jitpack.io' }
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -22,6 +27,8 @@ dependencies {
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 
+    // TODO: DiscordAppender 직접 구현
+    implementation 'com.github.napstr:logback-discord-appender:1.0.0' // for Discord Logs
     implementation 'com.github.f4b6a3:tsid-creator:5.2.6' // for Tsid generation
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator' // for monitoring

--- a/estime-api/src/main/java/com/estime/common/exception/GlobalExceptionHandler.java
+++ b/estime-api/src/main/java/com/estime/common/exception/GlobalExceptionHandler.java
@@ -3,7 +3,9 @@ package com.estime.common.exception;
 import com.estime.common.CustomApiResponse;
 import com.estime.common.exception.application.ApplicationException;
 import com.estime.common.exception.domain.DomainException;
+import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -25,6 +27,8 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public CustomApiResponse<Void> handleException(Exception e) {
+        MDC.put("message", e.getMessage());
+        MDC.put("details", Arrays.toString(e.getStackTrace()));
         log.error(e.getMessage());
         e.printStackTrace();
         return CustomApiResponse.internalServerError("서버에서 예기치 못한 에러가 발생했습니다.");

--- a/estime-api/src/main/java/com/estime/common/exception/GlobalExceptionHandler.java
+++ b/estime-api/src/main/java/com/estime/common/exception/GlobalExceptionHandler.java
@@ -27,7 +27,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     public CustomApiResponse<Void> handleException(Exception e) {
         MDC.put("message", e.getMessage());
-        log.error(e.getMessage(), e);
+        log.error(e.getMessage());
         return CustomApiResponse.internalServerError("서버에서 예기치 못한 에러가 발생했습니다.");
     }
 }

--- a/estime-api/src/main/java/com/estime/common/exception/GlobalExceptionHandler.java
+++ b/estime-api/src/main/java/com/estime/common/exception/GlobalExceptionHandler.java
@@ -3,7 +3,6 @@ package com.estime.common.exception;
 import com.estime.common.CustomApiResponse;
 import com.estime.common.exception.application.ApplicationException;
 import com.estime.common.exception.domain.DomainException;
-import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -28,9 +27,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     public CustomApiResponse<Void> handleException(Exception e) {
         MDC.put("message", e.getMessage());
-        MDC.put("details", Arrays.toString(e.getStackTrace()));
-        log.error(e.getMessage());
-        e.printStackTrace();
+        log.error(e.getMessage(), e);
         return CustomApiResponse.internalServerError("서버에서 예기치 못한 에러가 발생했습니다.");
     }
 }

--- a/estime-api/src/main/java/com/estime/common/logging/ApiLogFilter.java
+++ b/estime-api/src/main/java/com/estime/common/logging/ApiLogFilter.java
@@ -1,5 +1,13 @@
 package com.estime.common.logging;
 
+import static com.estime.common.logging.MdcKey.CLIENT_IP;
+import static com.estime.common.logging.MdcKey.HOST;
+import static com.estime.common.logging.MdcKey.HTTP_METHOD;
+import static com.estime.common.logging.MdcKey.QUERY_STRING;
+import static com.estime.common.logging.MdcKey.REQUEST_URI;
+import static com.estime.common.logging.MdcKey.TRACE_ID;
+import static com.estime.common.logging.MdcKey.USER_AGENT;
+
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -18,7 +26,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class ApiLogFilter implements Filter {
 
-    private static final String TRACE_ID_KEY = "traceId";
     private static final String REQUEST_ID_HEADER = "X-Request-Id";
 
     @Override
@@ -31,14 +38,7 @@ public class ApiLogFilter implements Filter {
                 .filter(s -> !s.isBlank())
                 .orElseGet(this::generateTraceId);
 
-        MDC.put(TRACE_ID_KEY, traceId);
-        MDC.put("host", request.getHeader("host"));
-        MDC.put("httpMethod", request.getMethod());
-        MDC.put("requestUri", request.getRequestURI());
-        MDC.put("queryString", request.getQueryString());
-        MDC.put("clientIp", request.getRemoteAddr());
-        MDC.put("userAgent", request.getHeader("User-Agent"));
-
+        populateMDC(traceId, request);
         response.setHeader(REQUEST_ID_HEADER, traceId);
 
         final long startTime = System.currentTimeMillis();
@@ -79,5 +79,15 @@ public class ApiLogFilter implements Filter {
 
     private String generateTraceId() {
         return UUID.randomUUID().toString().substring(0, 8);
+    }
+
+    private void populateMDC(final String traceId, final HttpServletRequest request) {
+        MDC.put(TRACE_ID.getKey(), traceId);
+        MDC.put(HOST.getKey(), request.getHeader("host"));
+        MDC.put(HTTP_METHOD.getKey(), request.getMethod());
+        MDC.put(REQUEST_URI.getKey(), request.getRequestURI());
+        MDC.put(QUERY_STRING.getKey(), request.getQueryString());
+        MDC.put(CLIENT_IP.getKey(), request.getRemoteAddr());
+        MDC.put(USER_AGENT.getKey(), request.getHeader("User-Agent"));
     }
 }

--- a/estime-api/src/main/java/com/estime/common/logging/ApiLogFilter.java
+++ b/estime-api/src/main/java/com/estime/common/logging/ApiLogFilter.java
@@ -32,6 +32,13 @@ public class ApiLogFilter implements Filter {
                 .orElseGet(this::generateTraceId);
 
         MDC.put(TRACE_ID_KEY, traceId);
+        MDC.put("host", request.getHeader("host"));
+        MDC.put("httpMethod", request.getMethod());
+        MDC.put("requestUri", request.getRequestURI());
+        MDC.put("queryString", request.getQueryString());
+        MDC.put("clientIp", request.getRemoteAddr());
+        MDC.put("userAgent", request.getHeader("User-Agent"));
+
         response.setHeader(REQUEST_ID_HEADER, traceId);
 
         final long startTime = System.currentTimeMillis();

--- a/estime-api/src/main/java/com/estime/common/logging/ApiLogFilter.java
+++ b/estime-api/src/main/java/com/estime/common/logging/ApiLogFilter.java
@@ -1,0 +1,91 @@
+package com.estime.common.logging;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class ApiLogFilter implements Filter {
+
+    private static final String TRACE_ID_KEY = "traceId";
+
+    @Override
+    public void doFilter(final ServletRequest servletRequest, final ServletResponse servletResponse,
+                         final FilterChain filterChain) throws IOException, ServletException {
+        final HttpServletRequest request = (HttpServletRequest) servletRequest;
+        final HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+        final String traceId = generateTraceId();
+        MDC.put(TRACE_ID_KEY, traceId);
+        MDC.put("host", request.getHeader("host"));
+        MDC.put("httpMethod", request.getMethod());
+        MDC.put("requestUri", request.getRequestURI());
+        MDC.put("queryString", request.getQueryString());
+        MDC.put("clientIp", request.getRemoteAddr());
+        MDC.put("userAgent", request.getHeader("User-Agent"));
+
+        final long startTime = System.currentTimeMillis();
+        logRequest(request);
+
+        try {
+            filterChain.doFilter(servletRequest, servletResponse);
+            logResponse(response, startTime);
+        } catch (final Exception ex) {
+            logError(request, ex, startTime);
+            throw ex;
+        } finally {
+            MDC.clear();
+        }
+    }
+
+    private void logRequest(final HttpServletRequest request) {
+        final String uri = request.getRequestURI();
+        final String method = request.getMethod();
+        final String ip = request.getRemoteAddr();
+        final String query = request.getQueryString();
+        final String userAgent = request.getHeader("User-Agent");
+
+        log.info("[REQ] layer=filter | ip={} | method={} | uri={}{} | ua={}",
+                ip, method, uri,
+                (query != null ? "?" + query : ""),
+                (userAgent != null ? userAgent : "-")
+        );
+    }
+
+    private void logResponse(final HttpServletResponse response, final long startTime) {
+        final long duration = System.currentTimeMillis() - startTime;
+        final int status = response.getStatus();
+        final String contentType = response.getContentType();
+        final int contentLength = response.getBufferSize();
+
+        log.info("[RES] layer=filter | status={} | duration={}ms | contentType={} | length={}",
+                status, duration,
+                (contentType != null ? contentType : "-"),
+                (contentLength > 0 ? contentLength + "B" : "-")
+        );
+    }
+
+    private void logError(final HttpServletRequest request, final Exception ex, final long startTime) {
+        final long duration = System.currentTimeMillis() - startTime;
+        final String uri = request.getRequestURI();
+        final String method = request.getMethod();
+        final int status = 500;
+
+        log.error("[ERR] layer=filter | method={} | uri={} | duration={}ms | status={} | error={}",
+                method, uri, duration, status, ex.toString(), ex);
+    }
+
+    private String generateTraceId() {
+        return UUID.randomUUID().toString().substring(0, 8);
+    }
+}

--- a/estime-api/src/main/java/com/estime/common/logging/MdcKey.java
+++ b/estime-api/src/main/java/com/estime/common/logging/MdcKey.java
@@ -1,0 +1,19 @@
+package com.estime.common.logging;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MdcKey {
+
+    TRACE_ID("traceId"),
+    HOST("host"),
+    HTTP_METHOD("httpMethod"),
+    REQUEST_URI("requestUri"),
+    QUERY_STRING("queryString"),
+    CLIENT_IP("clientIp"),
+    USER_AGENT("userAgent");
+
+    private final String key;
+}

--- a/estime-api/src/main/resources/application-common.yml
+++ b/estime-api/src/main/resources/application-common.yml
@@ -19,6 +19,4 @@ slack:
     token: ${SLACK_BOT_TOKEN}
 
 logging:
-  discord:
-    webhook-url: ${DISCORD_LOG_WEBHOOK_URL}
   config: classpath:logback.xml

--- a/estime-api/src/main/resources/application-common.yml
+++ b/estime-api/src/main/resources/application-common.yml
@@ -21,3 +21,8 @@ discord:
 slack:
   bot:
     token: ${SLACK_BOT_TOKEN}
+
+logging:
+  discord:
+    webhook-url: ${DISCORD_LOG_WEBHOOK_URL}
+  config: classpath:logback.xml

--- a/estime-api/src/main/resources/application-dev.yml
+++ b/estime-api/src/main/resources/application-dev.yml
@@ -35,3 +35,4 @@ management:
         enabled: true
         namespace: "EC2/estime-api/dev"
         region: ap-northeast-2
+        url: ${CLOUDWATCH_URL}

--- a/estime-api/src/main/resources/application-dev.yml
+++ b/estime-api/src/main/resources/application-dev.yml
@@ -31,6 +31,8 @@ logging:
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{traceId}] %-5level %logger{36} - %msg%n"
     file: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{traceId}] %-5level %logger{36} - %msg%n"
+  discord:
+    webhook-url: ${DISCORD_LOG_WEBHOOK_URL}
 
 management:
   metrics:

--- a/estime-api/src/main/resources/application-local.yml
+++ b/estime-api/src/main/resources/application-local.yml
@@ -28,6 +28,3 @@ logging:
     com.estime: DEBUG
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{traceId}] %-5level %logger{36} - %msg%n"
-  # TODO: 디버깅용, 삭제예정
-  cloudwatch:
-    url: ${CLOUDWATCH_URL}

--- a/estime-api/src/main/resources/application-local.yml
+++ b/estime-api/src/main/resources/application-local.yml
@@ -21,3 +21,6 @@ logging:
     com.estime: DEBUG
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{traceId}] %-5level %logger{36} - %msg%n"
+  # TODO: 디버깅용, 삭제예정
+  cloudwatch:
+    url: ${CLOUDWATCH_URL}

--- a/estime-api/src/main/resources/application-prod.yml
+++ b/estime-api/src/main/resources/application-prod.yml
@@ -23,6 +23,8 @@ logging:
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{traceId}] %-5level %logger{36} - %msg%n"
     file: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{traceId}] %-5level %logger{36} - %msg%n"
+  discord:
+    webhook-url: ${DISCORD_LOG_WEBHOOK_URL}
 
 management:
   metrics:

--- a/estime-api/src/main/resources/application-prod.yml
+++ b/estime-api/src/main/resources/application-prod.yml
@@ -28,3 +28,4 @@ management:
         enabled: true
         namespace: "EC2/estime-api/prod"
         region: ap-northeast-2
+        url: ${CLOUDWATCH_URL}

--- a/estime-api/src/main/resources/logback.xml
+++ b/estime-api/src/main/resources/logback.xml
@@ -1,0 +1,84 @@
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <!-- dev 환경 -->
+    <springProfile name="dev">
+        <springProperty name="DISCORD_LOG_WEBHOOK_URL" source="logging.discord.webhook-url"/>
+        <springProperty name="CLOUDWATCH_URL" source="logging.cloudwatch.url" />
+
+        <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
+            <webhookUri>${DISCORD_LOG_WEBHOOK_URL}</webhookUri>
+            <layout class="ch.qos.logback.classic.PatternLayout">
+                <pattern>
+                    ### [Summary]%n%mdc{message}%n
+                    ### [Time]%n%d{yyyy-MM-dd HH:mm:ss}%n
+                    ### [Level]%n%-5level%n
+                    ### [Trace Id]%n%mdc{traceId}%n
+                    ### [User Agent]%n%mdc{userAgent}%n
+                    ### [Client IP]%n%mdc{clientIp}%n
+                    ### [CloudWatch]%n ${CLOUDWATCH_URL}%n
+                    ### [Header]%n- host: %mdc{host}%n- uri: %mdc{httpMethod}  %mdc{requestUri}%mdc{query}%n
+                    ### [Details]%n```%mdc{details}```
+                </pattern>
+            </layout>
+            <username>🚨DEV ERROR LOGS 🚨</username>
+            <tts>false</tts>
+        </appender>
+
+        <appender name="ASYNC_DISCORD" class="ch.qos.logback.classic.AsyncAppender">
+            <appender-ref ref="DISCORD" />
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>ERROR</level>
+            </filter>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="ASYNC_DISCORD"/>
+            <appender-ref ref="Console"/>
+        </root>
+    </springProfile>
+
+    <!-- prod 환경 -->
+    <springProfile name="local">
+        <springProperty name="DISCORD_LOG_WEBHOOK_URL" source="logging.discord.webhook-url"/>
+        <springProperty name="CLOUDWATCH_URL" source="logging.cloudwatch.url" />
+
+        <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
+            <webhookUri>${DISCORD_LOG_WEBHOOK_URL}</webhookUri>
+            <layout class="ch.qos.logback.classic.PatternLayout">
+                <pattern>
+                    ### [Summary]%n%mdc{message}%n
+                    ### [Time]%n%d{yyyy-MM-dd HH:mm:ss}%n
+                    ### [Level]%n%-5level%n
+                    ### [Trace Id]%n%mdc{traceId}%n
+                    ### [Client IP]%n%mdc{clientIp}%n
+                    ### [CloudWatch]%n ${CLOUDWATCH_URL}%n
+                    ### [Header]%n- host: %mdc{host}%n- uri: %mdc{httpMethod}  %mdc{requestUri}%mdc{query}%n
+                    ### [Details]%n```%mdc{details}```
+                </pattern>
+            </layout>
+            <username>🚨PROD ERROR LOGS 🚨</username>
+            <tts>false</tts>
+        </appender>
+
+        <appender name="ASYNC_DISCORD" class="ch.qos.logback.classic.AsyncAppender">
+            <appender-ref ref="DISCORD" />
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>ERROR</level>
+            </filter>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="ASYNC_DISCORD"/>
+            <appender-ref ref="Console"/>
+        </root>
+    </springProfile>
+
+    <!-- 공통 콘솔 로거 -->
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <Pattern>${CONSOLE_LOG_PATTERN}</Pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+</configuration>

--- a/estime-api/src/main/resources/logback.xml
+++ b/estime-api/src/main/resources/logback.xml
@@ -16,7 +16,7 @@
         <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
             <webhookUri>${DISCORD_LOG_WEBHOOK_URL}</webhookUri>
             <layout class="ch.qos.logback.classic.PatternLayout">
-                <pattern>### [Summary]%n%msg%n### [Time]%n%d{yyyy-MM-dd HH:mm:ss}%n### [Level]%n%-5level%n### [Trace Id]%n%mdc{traceId}%n### [CloudWatch]%n ${CLOUDWATCH_URL}%n### [Header]%n- host: %mdc{host}%n- uri: %mdc{httpMethod}  %mdc{requestUri}%mdc{query}%n### [Details]%n</pattern>
+                <pattern>### [Summary]%n%msg%n### [Time]%n%d{yyyy-MM-dd HH:mm:ss}%n### [Level]%n%-5level%n### [Trace Id]%n%mdc{traceId}%n### [Header]%n- host: %mdc{host}%n- uri: %mdc{httpMethod}  %mdc{requestUri}%mdc{query}%n### [CloudWatch]%n ${CLOUDWATCH_URL}%n</pattern>
             </layout>
             <username>🚨DEV ERROR LOGS 🚨</username>
             <tts>false</tts>
@@ -43,7 +43,7 @@
         <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
             <webhookUri>${DISCORD_LOG_WEBHOOK_URL}</webhookUri>
             <layout class="ch.qos.logback.classic.PatternLayout">
-                <pattern>### [Summary]%n%msg%n### [Time]%n%d{yyyy-MM-dd HH:mm:ss}%n### [Level]%n%-5level%n### [Trace Id]%n%mdc{traceId}%n### [User Agent]%n%mdc{userAgent}%n### [Client IP]%n%mdc{clientIp}%n### [CloudWatch]%n ${CLOUDWATCH_URL}%n### [Header]%n- host: %mdc{host}%n- uri: %mdc{httpMethod}  %mdc{requestUri}%mdc{query}%n### [Details]%n</pattern>
+                <pattern>### [Summary]%n%msg%n### [Time]%n%d{yyyy-MM-dd HH:mm:ss}%n### [Level]%n%-5level%n### [Trace Id]%n%mdc{traceId}%n### [User Agent]%n%mdc{userAgent}%n### [Client IP]%n%mdc{clientIp}%n### [Header]%n- host: %mdc{host}%n- uri: %mdc{httpMethod}  %mdc{requestUri}%mdc{query}%n### [CloudWatch]%n ${CLOUDWATCH_URL}%n</pattern>
             </layout>
             <username>🚨PROD ERROR LOGS 🚨</username>
             <tts>false</tts>

--- a/estime-api/src/main/resources/logback.xml
+++ b/estime-api/src/main/resources/logback.xml
@@ -16,7 +16,7 @@
         <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
             <webhookUri>${DISCORD_LOG_WEBHOOK_URL}</webhookUri>
             <layout class="ch.qos.logback.classic.PatternLayout">
-                <pattern>### [Summary]%n%mdc{message}%n### [Time]%n%d{yyyy-MM-dd HH:mm:ss}%n### [Level]%n%-5level%n### [Trace Id]%n%mdc{traceId}%n### [CloudWatch]%n ${CLOUDWATCH_URL}%n### [Header]%n- host: %mdc{host}%n- uri: %mdc{httpMethod}  %mdc{requestUri}%mdc{query}%n### [Details]%n```%mdc{details}```</pattern>
+                <pattern>### [Summary]%n%msg%n### [Time]%n%d{yyyy-MM-dd HH:mm:ss}%n### [Level]%n%-5level%n### [Trace Id]%n%mdc{traceId}%n### [CloudWatch]%n ${CLOUDWATCH_URL}%n### [Header]%n- host: %mdc{host}%n- uri: %mdc{httpMethod}  %mdc{requestUri}%mdc{query}%n### [Details]%n</pattern>
             </layout>
             <username>🚨DEV ERROR LOGS 🚨</username>
             <tts>false</tts>
@@ -43,7 +43,7 @@
         <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
             <webhookUri>${DISCORD_LOG_WEBHOOK_URL}</webhookUri>
             <layout class="ch.qos.logback.classic.PatternLayout">
-                <pattern>### [Summary]%n%mdc{message}%n### [Time]%n%d{yyyy-MM-dd HH:mm:ss}%n### [Level]%n%-5level%n### [Trace Id]%n%mdc{traceId}%n### [User Agent]%n%mdc{userAgent}%n### [Client IP]%n%mdc{clientIp}%n### [CloudWatch]%n ${CLOUDWATCH_URL}%n### [Header]%n- host: %mdc{host}%n- uri: %mdc{httpMethod}  %mdc{requestUri}%mdc{query}%n### [Details]%n```%mdc{details}```</pattern>
+                <pattern>### [Summary]%n%msg%n### [Time]%n%d{yyyy-MM-dd HH:mm:ss}%n### [Level]%n%-5level%n### [Trace Id]%n%mdc{traceId}%n### [User Agent]%n%mdc{userAgent}%n### [Client IP]%n%mdc{clientIp}%n### [CloudWatch]%n ${CLOUDWATCH_URL}%n### [Header]%n- host: %mdc{host}%n- uri: %mdc{httpMethod}  %mdc{requestUri}%mdc{query}%n### [Details]%n</pattern>
             </layout>
             <username>🚨PROD ERROR LOGS 🚨</username>
             <tts>false</tts>

--- a/estime-api/src/main/resources/logback.xml
+++ b/estime-api/src/main/resources/logback.xml
@@ -1,25 +1,22 @@
 <configuration>
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
+    <!-- local 환경-->
+    <springProfile name="local">
+        <root level="INFO">
+            <appender-ref ref="Console"/>
+        </root>
+    </springProfile>
+
     <!-- dev 환경 -->
     <springProfile name="dev">
         <springProperty name="DISCORD_LOG_WEBHOOK_URL" source="logging.discord.webhook-url"/>
-        <springProperty name="CLOUDWATCH_URL" source="logging.cloudwatch.url" />
+        <springProperty name="CLOUDWATCH_URL" source="management.metrics.export.cloudwatch.url" />
 
         <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
             <webhookUri>${DISCORD_LOG_WEBHOOK_URL}</webhookUri>
             <layout class="ch.qos.logback.classic.PatternLayout">
-                <pattern>
-                    ### [Summary]%n%mdc{message}%n
-                    ### [Time]%n%d{yyyy-MM-dd HH:mm:ss}%n
-                    ### [Level]%n%-5level%n
-                    ### [Trace Id]%n%mdc{traceId}%n
-                    ### [User Agent]%n%mdc{userAgent}%n
-                    ### [Client IP]%n%mdc{clientIp}%n
-                    ### [CloudWatch]%n ${CLOUDWATCH_URL}%n
-                    ### [Header]%n- host: %mdc{host}%n- uri: %mdc{httpMethod}  %mdc{requestUri}%mdc{query}%n
-                    ### [Details]%n```%mdc{details}```
-                </pattern>
+                <pattern>### [Summary]%n%mdc{message}%n### [Time]%n%d{yyyy-MM-dd HH:mm:ss}%n### [Level]%n%-5level%n### [Trace Id]%n%mdc{traceId}%n### [CloudWatch]%n ${CLOUDWATCH_URL}%n### [Header]%n- host: %mdc{host}%n- uri: %mdc{httpMethod}  %mdc{requestUri}%mdc{query}%n### [Details]%n```%mdc{details}```</pattern>
             </layout>
             <username>🚨DEV ERROR LOGS 🚨</username>
             <tts>false</tts>
@@ -39,23 +36,14 @@
     </springProfile>
 
     <!-- prod 환경 -->
-    <springProfile name="local">
+    <springProfile name="prod">
         <springProperty name="DISCORD_LOG_WEBHOOK_URL" source="logging.discord.webhook-url"/>
-        <springProperty name="CLOUDWATCH_URL" source="logging.cloudwatch.url" />
+        <springProperty name="CLOUDWATCH_URL" source="management.metrics.export.cloudwatch.url" />
 
         <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
             <webhookUri>${DISCORD_LOG_WEBHOOK_URL}</webhookUri>
             <layout class="ch.qos.logback.classic.PatternLayout">
-                <pattern>
-                    ### [Summary]%n%mdc{message}%n
-                    ### [Time]%n%d{yyyy-MM-dd HH:mm:ss}%n
-                    ### [Level]%n%-5level%n
-                    ### [Trace Id]%n%mdc{traceId}%n
-                    ### [Client IP]%n%mdc{clientIp}%n
-                    ### [CloudWatch]%n ${CLOUDWATCH_URL}%n
-                    ### [Header]%n- host: %mdc{host}%n- uri: %mdc{httpMethod}  %mdc{requestUri}%mdc{query}%n
-                    ### [Details]%n```%mdc{details}```
-                </pattern>
+                <pattern>### [Summary]%n%mdc{message}%n### [Time]%n%d{yyyy-MM-dd HH:mm:ss}%n### [Level]%n%-5level%n### [Trace Id]%n%mdc{traceId}%n### [User Agent]%n%mdc{userAgent}%n### [Client IP]%n%mdc{clientIp}%n### [CloudWatch]%n ${CLOUDWATCH_URL}%n### [Header]%n- host: %mdc{host}%n- uri: %mdc{httpMethod}  %mdc{requestUri}%mdc{query}%n### [Details]%n```%mdc{details}```</pattern>
             </layout>
             <username>🚨PROD ERROR LOGS 🚨</username>
             <tts>false</tts>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #306 

## 📝 작업 내용

- discord appender 추가 
- logback 설정을 통한 discord webhook 알림 구현
- prod, dev, local 프로파일 별 별도 설정 적용

### Discord 웹훅 흐름 
애플리케이션에 로그가 생성 시, 로그 이벤트가 로거에서 감지되고, 
로거는 `DiscordAppender` 에 (ERROR 단계의) 로그 이벤트를 전달합니다. 
`DiscordAppender` 에서 `Discord Webhook URL` 에 POST 요청을 보내고, 
Discord 서버가 응답을 받아 채널에 로그 알림 메세지를 표시합니다. 

```
[애플리케이션] 
     │
     ▼
[Logger (로그 이벤트 생성)]
     │
     ▼
[Discord Appender]
     │  -- HTTP POST --> Discord Webhook URL
     ▼
[Discord 채널에 메시지 표시]
```

## 💬 리뷰 요구사항
누락되거나, 수정해야할 로그 데이터가 있다면 말씀해주세요!
나머지 요구사항은 코드에 직접 코멘트로 남기겠습니다. 

### 현재 메세지 구조
Dev 서버: 에러메세지, 발생 시간, 에러레벨, 에러단계, `traceid`, `cloudwatch url`, `header(host, uri)`, `stacktrace`
Prod 서버: Dev서버 정보 += `user-agent` , `client ip`

