### PR TITLE
마감기한 이후 편집 불가능하도록 수정

### DIFF
--- a/estime-api/src/main/java/com/estime/common/exception/domain/DeadlineOverdueException.java
+++ b/estime-api/src/main/java/com/estime/common/exception/domain/DeadlineOverdueException.java
@@ -5,15 +5,15 @@ import com.estime.common.exception.util.ExceptionMessageFormatter;
 
 public class DeadlineOverdueException extends DomainException {
 
-    public DeadlineOverdueException(final DomainTerm term, final Object... params) {
+    public DeadlineOverdueException(final Object... params) {
         super(
-                buildLogMessage(term, params),
+                buildLogMessage(params),
                 buildUserMessage()
         );
     }
 
-    private static String buildLogMessage(final DomainTerm term, final Object... params) {
-        return ExceptionMessageFormatter.format("Deadline exceeded for %s".formatted(term), params);
+    private static String buildLogMessage(final Object... params) {
+        return ExceptionMessageFormatter.format("%s exceeded".formatted(DomainTerm.DEADLINE), params);
     }
 
     private static String buildUserMessage() {

--- a/estime-api/src/main/java/com/estime/common/exception/domain/DeadlineOverdueException.java
+++ b/estime-api/src/main/java/com/estime/common/exception/domain/DeadlineOverdueException.java
@@ -17,6 +17,6 @@ public class DeadlineOverdueException extends DomainException {
     }
 
     private static String buildUserMessage() {
-        return "마감시간이 경과되어 더이상 수정하실 수 없습니다. 결과를 확인해주세요.";
+        return "마감기한이 경과되어 더이상 추가/수정하실 수 없습니다. 결과를 확인해 주세요.";
     }
 }

--- a/estime-api/src/main/java/com/estime/common/exception/domain/DeadlineOverdueException.java
+++ b/estime-api/src/main/java/com/estime/common/exception/domain/DeadlineOverdueException.java
@@ -1,0 +1,22 @@
+package com.estime.common.exception.domain;
+
+import com.estime.common.DomainTerm;
+import com.estime.common.exception.util.ExceptionMessageFormatter;
+
+public class DeadlineOverdueException extends DomainException {
+
+    public DeadlineOverdueException(final DomainTerm term, final Object... params) {
+        super(
+                buildLogMessage(term, params),
+                buildUserMessage()
+        );
+    }
+
+    private static String buildLogMessage(final DomainTerm term, final Object... params) {
+        return ExceptionMessageFormatter.format("Deadline exceeded for %s".formatted(term), params);
+    }
+
+    private static String buildUserMessage() {
+        return "마감시간이 경과되어 더이상 수정하실 수 없습니다. 결과를 확인해주세요.";
+    }
+}

--- a/estime-api/src/main/java/com/estime/room/application/service/RoomApplicationService.java
+++ b/estime-api/src/main/java/com/estime/room/application/service/RoomApplicationService.java
@@ -93,7 +93,7 @@ public class RoomApplicationService {
                 .orElseThrow(() -> new NotFoundException(DomainTerm.ROOM, input.session()));
         final Long roomId = room.getId();
         final Long participantId = getParticipantIdByRoomIdAndName(roomId, input.participantName());
-        room.checkDeadlineOverdue(LocalDateTime.now());
+        room.ensureDeadlineNotPassed(LocalDateTime.now());
 
         final Votes originVotes = voteRepository.findAllByParticipantId(participantId);
         final Votes updatedVotes = Votes.from(input.toEntities(participantId));
@@ -109,7 +109,7 @@ public class RoomApplicationService {
         final Room room = roomRepository.findBySession(input.session())
                 .orElseThrow(() -> new NotFoundException(DomainTerm.ROOM, input.session()));
         final Long roomId = room.getId();
-        room.checkDeadlineOverdue(LocalDateTime.now());
+        room.ensureDeadlineNotPassed(LocalDateTime.now());
 
         final boolean isDuplicateName = participantRepository.existsByRoomIdAndName(roomId, input.participantName());
         if (!isDuplicateName) {

--- a/estime-api/src/main/java/com/estime/room/domain/Room.java
+++ b/estime-api/src/main/java/com/estime/room/domain/Room.java
@@ -102,7 +102,7 @@ public class Room extends BaseEntity {
         }
     }
 
-    public void checkDeadlineOverdue(final LocalDateTime currentDateTime) {
+    public void ensureDeadlineNotPassed(final LocalDateTime currentDateTime) {
         if (deadline.isBefore(currentDateTime)) {
             throw new DeadlineOverdueException(DomainTerm.DEADLINE, session, deadline, currentDateTime);
         }

--- a/estime-api/src/main/java/com/estime/room/domain/Room.java
+++ b/estime-api/src/main/java/com/estime/room/domain/Room.java
@@ -104,7 +104,7 @@ public class Room extends BaseEntity {
 
     public void ensureDeadlineNotPassed(final LocalDateTime currentDateTime) {
         if (deadline.isBefore(currentDateTime)) {
-            throw new DeadlineOverdueException(DomainTerm.DEADLINE, session, deadline, currentDateTime);
+            throw new DeadlineOverdueException(session, deadline, currentDateTime);
         }
     }
 }

--- a/estime-api/src/main/java/com/estime/room/domain/Room.java
+++ b/estime-api/src/main/java/com/estime/room/domain/Room.java
@@ -2,6 +2,7 @@ package com.estime.room.domain;
 
 import com.estime.common.BaseEntity;
 import com.estime.common.DomainTerm;
+import com.estime.common.exception.domain.DeadlineOverdueException;
 import com.estime.common.exception.domain.PastNotAllowedException;
 import com.estime.common.util.Validator;
 import com.estime.room.domain.slot.vo.DateSlot;
@@ -98,6 +99,12 @@ public class Room extends BaseEntity {
     private static void validateDeadline(final DateTimeSlot deadline) {
         if (deadline.isBefore(LocalDateTime.now())) {
             throw new PastNotAllowedException(DomainTerm.DEADLINE, deadline);
+        }
+    }
+
+    public void checkDeadlineOverdue(final LocalDateTime currentDateTime) {
+        if (deadline.isBefore(currentDateTime)) {
+            throw new DeadlineOverdueException(DomainTerm.DEADLINE, session, deadline, currentDateTime);
         }
     }
 }

--- a/estime-api/src/test/java/com/estime/room/domain/RoomTest.java
+++ b/estime-api/src/test/java/com/estime/room/domain/RoomTest.java
@@ -42,7 +42,7 @@ class RoomTest {
         });
     }
 
-    @DisplayName("checkDeadlineOverdue - 마감이 지났을 때 예외 발생")
+    @DisplayName("ensureDeadlineNotPassed - 마감이 지났을 때 예외 발생")
     @Test
     void ensureDeadlineNotPassed_expired_throwException() {
         Room room = Room.withoutId(
@@ -71,7 +71,7 @@ class RoomTest {
                 .hasMessageContaining(DomainTerm.DEADLINE.name());
     }
 
-    @DisplayName("checkDeadlineOverdue - 아직 마감 전이면 예외 발생 안 함")
+    @DisplayName("ensureDeadlineNotPassed - 아직 마감 전이면 예외 발생 안 함")
     @Test
     void ensureDeadlineNotPassed_notExpired_noException() {
         Room room = Room.withoutId(

--- a/estime-api/src/test/java/com/estime/room/domain/RoomTest.java
+++ b/estime-api/src/test/java/com/estime/room/domain/RoomTest.java
@@ -1,0 +1,87 @@
+package com.estime.room.domain;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.estime.common.DomainTerm;
+import com.estime.common.exception.domain.DeadlineOverdueException;
+import com.estime.common.exception.domain.PastNotAllowedException;
+import com.estime.room.domain.slot.vo.DateSlot;
+import com.estime.room.domain.slot.vo.DateTimeSlot;
+import com.estime.room.domain.slot.vo.TimeSlot;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RoomTest {
+
+    private final LocalDateTime now = LocalDateTime.now().withMinute(0).withSecond(0).withNano(0);
+    private final DateSlot dateSlot = DateSlot.from(LocalDate.of(2025, 8, 20));
+    private final TimeSlot timeSlot = TimeSlot.from(LocalTime.of(10, 0));
+    private final DateTimeSlot futureDeadline = DateTimeSlot.from(now.plusDays(1));
+    private final DateTimeSlot pastDeadline = DateTimeSlot.from(now.minusDays(1));
+
+    @DisplayName("정상적인 값으로 Room 생성 성공")
+    @Test
+    void createRoom_success() {
+        Room room = Room.withoutId(
+                "테스트방",
+                List.of(dateSlot),
+                List.of(timeSlot),
+                futureDeadline
+        );
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(room.getTitle()).isEqualTo("테스트방");
+            softly.assertThat(room.getAvailableDateSlots()).containsExactly(dateSlot);
+            softly.assertThat(room.getAvailableTimeSlots()).containsExactly(timeSlot);
+            softly.assertThat(room.getDeadline()).isEqualTo(futureDeadline);
+        });
+    }
+
+    @DisplayName("checkDeadlineOverdue - 마감이 지났을 때 예외 발생")
+    @Test
+    void checkDeadlineOverdue_expired_throwException() {
+        Room room = Room.withoutId(
+                "테스트방",
+                List.of(dateSlot),
+                List.of(timeSlot),
+                futureDeadline
+        );
+        assertThatThrownBy(() -> room.checkDeadlineOverdue(now.plusDays(2)))
+                .isInstanceOf(DeadlineOverdueException.class)
+                .hasMessageContaining(DomainTerm.DEADLINE.name());
+    }
+
+    @DisplayName("마감기한이 현재 시간 이전이면 PastNotAllowedException 발생")
+    @Test
+    void createRoom_pastDeadline_fail() {
+        assertThatThrownBy(() ->
+                Room.withoutId(
+                        "테스트방",
+                        List.of(dateSlot),
+                        List.of(timeSlot),
+                        pastDeadline
+                )
+        )
+                .isInstanceOf(PastNotAllowedException.class)
+                .hasMessageContaining(DomainTerm.DEADLINE.name());
+    }
+
+    @DisplayName("checkDeadlineOverdue - 아직 마감 전이면 예외 발생 안 함")
+    @Test
+    void checkDeadlineOverdue_notExpired_noException() {
+        Room room = Room.withoutId(
+                "테스트방",
+                List.of(dateSlot),
+                List.of(timeSlot),
+                futureDeadline
+        );
+        assertThatCode(() -> room.checkDeadlineOverdue(now))
+                .doesNotThrowAnyException();
+    }
+}

--- a/estime-api/src/test/java/com/estime/room/domain/RoomTest.java
+++ b/estime-api/src/test/java/com/estime/room/domain/RoomTest.java
@@ -9,7 +9,6 @@ import com.estime.common.exception.domain.PastNotAllowedException;
 import com.estime.room.domain.slot.vo.DateSlot;
 import com.estime.room.domain.slot.vo.DateTimeSlot;
 import com.estime.room.domain.slot.vo.TimeSlot;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
@@ -45,14 +44,14 @@ class RoomTest {
 
     @DisplayName("checkDeadlineOverdue - 마감이 지났을 때 예외 발생")
     @Test
-    void checkDeadlineOverdue_expired_throwException() {
+    void ensureDeadlineNotPassed_expired_throwException() {
         Room room = Room.withoutId(
                 "테스트방",
                 List.of(dateSlot),
                 List.of(timeSlot),
                 futureDeadline
         );
-        assertThatThrownBy(() -> room.checkDeadlineOverdue(now.plusDays(2)))
+        assertThatThrownBy(() -> room.ensureDeadlineNotPassed(now.plusDays(2)))
                 .isInstanceOf(DeadlineOverdueException.class)
                 .hasMessageContaining(DomainTerm.DEADLINE.name());
     }
@@ -74,14 +73,14 @@ class RoomTest {
 
     @DisplayName("checkDeadlineOverdue - 아직 마감 전이면 예외 발생 안 함")
     @Test
-    void checkDeadlineOverdue_notExpired_noException() {
+    void ensureDeadlineNotPassed_notExpired_noException() {
         Room room = Room.withoutId(
                 "테스트방",
                 List.of(dateSlot),
                 List.of(timeSlot),
                 futureDeadline
         );
-        assertThatCode(() -> room.checkDeadlineOverdue(now))
+        assertThatCode(() -> room.ensureDeadlineNotPassed(now))
                 .doesNotThrowAnyException();
     }
 }

--- a/estime-api/src/test/java/com/estime/room/domain/RoomTest.java
+++ b/estime-api/src/test/java/com/estime/room/domain/RoomTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 class RoomTest {
 
     private final LocalDateTime now = LocalDateTime.now().withMinute(0).withSecond(0).withNano(0);
-    private final DateSlot dateSlot = DateSlot.from(LocalDate.of(2025, 8, 20));
+    private final DateSlot dateSlot = DateSlot.from(now.toLocalDate().plusDays(1));
     private final TimeSlot timeSlot = TimeSlot.from(LocalTime.of(10, 0));
     private final DateTimeSlot futureDeadline = DateTimeSlot.from(now.plusDays(1));
     private final DateTimeSlot pastDeadline = DateTimeSlot.from(now.minusDays(1));


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #257 
- close #380 

## 📝 작업 내용

- 데드라인 커스텀 예외 `DeadlineOverdueException` 구현 

`buildUserMessage` 는 프론트와의 협의 후 결정하였습니다. 
> "마감시간이 경과되어 더이상 수정하실 수 없습니다. 결과를 확인해주세요."

- 도메인 내 데드라인 체크 메서드 `checkDeadlineOverdue` 추가

- 참여자 등록, 투표 시 데드라인 체크


## 💬 리뷰 요구사항

`checkDeadlineOverdue` 이외의 더 좋은 메서드 이름 추천해 주세요. 