### PR TITLE
방에서 선택 불가능한 타임슬롯에 대한 요청 예외 처리

### DIFF
--- a/estime-api/src/main/java/com/estime/common/exception/domain/UnavailableSlotException.java
+++ b/estime-api/src/main/java/com/estime/common/exception/domain/UnavailableSlotException.java
@@ -1,0 +1,23 @@
+package com.estime.common.exception.domain;
+
+import com.estime.common.DomainTerm;
+import com.estime.common.exception.util.ExceptionMessageFormatter;
+
+public class UnavailableSlotException extends DomainException {
+
+    public UnavailableSlotException(final DomainTerm term, final Object... params) {
+        super(
+                buildLogMessage(term, params),
+                buildUserMessage(term)
+        );
+    }
+
+    private static String buildLogMessage(final DomainTerm term, final Object... params) {
+        return ExceptionMessageFormatter.format("%s is outside the available range".formatted(term),
+                params);
+    }
+
+    private static String buildUserMessage(final DomainTerm term) {
+        return "선택할 수 없는 %s 입니다.".formatted(term.label());
+    }
+}

--- a/estime-api/src/main/java/com/estime/room/application/service/RoomApplicationService.java
+++ b/estime-api/src/main/java/com/estime/room/application/service/RoomApplicationService.java
@@ -92,7 +92,10 @@ public class RoomApplicationService {
 
     @Transactional
     public Votes updateParticipantVotes(final VotesUpdateInput input) {
-        final Long roomId = getRoomIdBySession(input.session());
+        final Room room = roomRepository.findBySession(input.session())
+                .orElseThrow(() -> new NotFoundException(DomainTerm.ROOM, input.session()));
+        final Long roomId = room.getId();
+        room.ensureAvailableDateTimeSlots(input.dateTimeSlots());
 
         final Long participantId = participantRepository.findIdByRoomIdAndName(roomId, input.participantName())
                 .orElseThrow(() -> new NotFoundException(DomainTerm.PARTICIPANT, roomId, input.participantName()));

--- a/estime-api/src/main/java/com/estime/room/domain/Room.java
+++ b/estime-api/src/main/java/com/estime/room/domain/Room.java
@@ -3,6 +3,7 @@ package com.estime.room.domain;
 import com.estime.common.BaseEntity;
 import com.estime.common.DomainTerm;
 import com.estime.common.exception.domain.PastNotAllowedException;
+import com.estime.common.exception.domain.UnavailableSlotException;
 import com.estime.common.util.Validator;
 import com.estime.room.domain.slot.vo.DateSlot;
 import com.estime.room.domain.slot.vo.DateTimeSlot;
@@ -98,6 +99,16 @@ public class Room extends BaseEntity {
     private static void validateDeadline(final DateTimeSlot deadline) {
         if (deadline.isBefore(LocalDateTime.now())) {
             throw new PastNotAllowedException(DomainTerm.DEADLINE, deadline);
+        }
+    }
+
+    public void ensureAvailableDateTimeSlots(final List<DateTimeSlot> dateTimeSlots) {
+        for (DateTimeSlot dateTimeSlot : dateTimeSlots) {
+            final DateSlot dateSlot = dateTimeSlot.toDateSlot();
+            final TimeSlot timeSlot = dateTimeSlot.toTimeSlot();
+            if (!availableDateSlots.contains(dateSlot) || !availableTimeSlots.contains(timeSlot)) {
+                throw new UnavailableSlotException(DomainTerm.DATE_TIME_SLOT, session, dateTimeSlot);
+            }
         }
     }
 }

--- a/estime-api/src/main/java/com/estime/room/domain/slot/vo/DateTimeSlot.java
+++ b/estime-api/src/main/java/com/estime/room/domain/slot/vo/DateTimeSlot.java
@@ -26,6 +26,10 @@ public class DateTimeSlot implements Comparable<DateTimeSlot> {
         return new DateTimeSlot(startAt);
     }
 
+    public static DateTimeSlot of(final DateSlot dateSlot, final TimeSlot timeSlot) {
+        return from(LocalDateTime.of(dateSlot.getStartAt(), timeSlot.getStartAt()));
+    }
+
     private static void validateNull(final LocalDateTime startAt) {
         Validator.builder()
                 .add("startAt", startAt)
@@ -36,6 +40,14 @@ public class DateTimeSlot implements Comparable<DateTimeSlot> {
         if (startAt.getMinute() != 0 && startAt.getMinute() != UNIT.toMinutes()) {
             throw new SlotNotDivideException(DomainTerm.DATE_TIME_SLOT, startAt);
         }
+    }
+
+    public DateSlot toDateSlot() {
+        return DateSlot.from(startAt.toLocalDate());
+    }
+
+    public TimeSlot toTimeSlot() {
+        return TimeSlot.from(startAt.toLocalTime());
     }
 
     public boolean isBefore(final LocalDateTime other) {

--- a/estime-api/src/test/java/com/estime/room/application/service/RoomApplicationServiceTest.java
+++ b/estime-api/src/test/java/com/estime/room/application/service/RoomApplicationServiceTest.java
@@ -63,7 +63,11 @@ class RoomApplicationServiceTest {
                 Room.withoutId(
                         "test",
                         List.of(DateSlot.from(LocalDate.now().plusDays(1))),
-                        List.of(TimeSlot.from(LocalTime.of(10, 0))),
+                        List.of(TimeSlot.from(LocalTime.of(10, 0)),
+                                TimeSlot.from(LocalTime.of(10, 30)),
+                                TimeSlot.from(LocalTime.of(11, 0)),
+                                TimeSlot.from(LocalTime.of(11, 30))
+                        ),
                         DateTimeSlot.from(LocalDateTime.of(LocalDate.now().plusDays(3), LocalTime.of(10, 0)))
                 ));
 

--- a/estime-api/src/test/java/com/estime/room/application/service/RoomApplicationServiceTest.java
+++ b/estime-api/src/test/java/com/estime/room/application/service/RoomApplicationServiceTest.java
@@ -301,9 +301,9 @@ class RoomApplicationServiceTest {
         assertThat(output.isDuplicateName()).isTrue();
     }
 
-    @DisplayName("사용 불가능한 DateTimeSlot으로 투표를 업데이트하면 UnavailableSlotException이 발생한다.")
+    @DisplayName("사용 불가능한 DateSlot으로 투표를 업데이트하면 UnavailableSlotException이 발생한다.")
     @Test
-    void updateParticipantVotes_withUnavailableDateTimeSlot() {
+    void updateParticipantVotes_withUnavailableDateSlot() {
         // given
         final DateTimeSlot unavailableDateSlot = DateTimeSlot.from(
                 LocalDateTime.of(LocalDate.now().plusDays(2), LocalTime.of(10, 0)));


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #404 

## 📝 작업 내용

- `UnavailableSlotException` 커스텀 예외 생성
    - 선택할 수 없는 slot관련 요청이 들어왔을 때 사용하는 예외입니다.

- `ensureAvailableDateTimeSlots()` 메서드 구현
    - 투표 요청 시 검증을 추가합니다.
    - 서버로 직접 선택할 수 없는 slot이 들어오는 것을 방지하기 위한 목적입니다.
    - ex) Room 의 선택가능한 타임 슬롯이 `10:00` , `10:30` 존재할 때, `11:00` 의 투표가 정상적으로 이루어지는 것을 방지합니다. 

## 💬 리뷰 요구사항

최적화에 대한 내용은 추후 다루겠습니다.