### PR TITLE
SSE 이벤트 전송 시 name/id/data를 포함하도록 개선

### DIFF
--- a/estime-api/src/main/java/com/estime/common/sse/application/SseSender.java
+++ b/estime-api/src/main/java/com/estime/common/sse/application/SseSender.java
@@ -2,6 +2,7 @@ package com.estime.common.sse.application;
 
 import com.estime.common.sse.domain.SseEmitters;
 import com.github.f4b6a3.tsid.Tsid;
+import com.github.f4b6a3.tsid.TsidCreator;
 import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -14,12 +15,17 @@ public class SseSender {
 
     private final SseEmitters sseEmitters;
 
-    public void sendMessage(Tsid roomSession, String message) {
+    public void broadcast(final Tsid roomSession, final String message) {
         final List<SseEmitter> emitters = sseEmitters.findAllByRoomSession(roomSession);
-        for (SseEmitter emitter : emitters) {
+        for (final SseEmitter emitter : emitters) {
             try {
-                emitter.send(SseEmitter.event().data(message));
-            } catch (IOException e) {
+                emitter.send(
+                        SseEmitter.event()
+                                .name(message)
+                                .id(TsidCreator.getTsid().toString())
+                                .data("ok")
+                );
+            } catch (final IOException e) {
                 throw new RuntimeException("Failed to send SSE message for roomSession " + roomSession + ":" + e.getMessage(), e);
             }
         }

--- a/estime-api/src/main/java/com/estime/common/sse/application/SseService.java
+++ b/estime-api/src/main/java/com/estime/common/sse/application/SseService.java
@@ -10,7 +10,7 @@ public class SseService {
 
     private final SseSender sseSender;
 
-    public void sendSseByRoomSession(Tsid roomSession, String message) {
-        sseSender.sendMessage(roomSession, message);
+    public void sendSseByRoomSession(final Tsid roomSession, final String message) {
+        sseSender.broadcast(roomSession, message);
     }
 }

--- a/estime-api/src/main/java/com/estime/common/sse/presentation/SseController.java
+++ b/estime-api/src/main/java/com/estime/common/sse/presentation/SseController.java
@@ -2,6 +2,7 @@ package com.estime.common.sse.presentation;
 
 import com.estime.common.sse.application.SseSubscriptionManager;
 import com.github.f4b6a3.tsid.Tsid;
+import com.github.f4b6a3.tsid.TsidCreator;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,9 +24,14 @@ public class SseController {
     public SseEmitter stream(@PathVariable("session") final Tsid roomSession) {
         final SseEmitter emitter = subscriptionManager.subscribe(roomSession);
         try {
-            emitter.send(SseEmitter.event().data("connected"));
-        } catch (IOException e) {
-            log.error("Failed to send SSE 'connected' event for session {}: {}", roomSession, e.getMessage(), e);
+            emitter.send(
+                    SseEmitter.event()
+                            .name("connected")
+                            .id(TsidCreator.getTsid().toString())
+                            .data("ok")
+            );
+        } catch (final IOException e) {
+            log.error("Failed to send SSE event [connected] for roomSession {}: {}", roomSession, e.getMessage(), e);
             emitter.complete();
         }
         return emitter;

--- a/estime-api/src/main/java/com/estime/room/application/service/RoomApplicationService.java
+++ b/estime-api/src/main/java/com/estime/room/application/service/RoomApplicationService.java
@@ -109,8 +109,8 @@ public class RoomApplicationService {
 
         try {
             sseService.sendSseByRoomSession(input.session().getRoomSession(), "vote-changed");
-        } catch (Exception ignored) {
-            log.warn("투표 갱신 이후 sse 전송 실패: {}", input.session().getRoomSession().toString());
+        } catch (final Exception ignored) {
+            log.warn("Failed to send SSE event [vote-changed] for roomSession {}", input.session().getRoomSession().toString());
         }
 
         return updatedVotes;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #435 

## 📝 작업 내용

- SSE 이벤트(vote-changed, connected) 전송 방식을 단순 data 기반 → 명시적 이벤트 구조(name, id, data) 기반으로 변경
  - 이벤트 id 생성 시 `System.currentTimeMillis()` 대신 `TsidCreator` 사용하여 충돌 위험 최소화 및 시간 정렬성 보장
  - data 필드를 "ok" 값으로 통일

## 💬 리뷰 요구사항
