### PR TITLE
CD 스크립트에 기존 .env 파일 백업 스크립트 추가

### DIFF
--- a/.github/workflows/CD-dev.yml
+++ b/.github/workflows/CD-dev.yml
@@ -96,8 +96,8 @@ jobs:
         working-directory: ./estime-api
         run: |
           if [ -f .env.dev ]; then
-            echo "Found .env.dev, backing up to .env.before"
-            mv .env.dev .env.before
+            echo "Found .env.dev, backing up to .env.dev.before"
+            mv .env.dev .env.dev.before
           else
             echo "No .env.dev file found, skipping backup."
           fi

--- a/.github/workflows/CD-dev.yml
+++ b/.github/workflows/CD-dev.yml
@@ -95,7 +95,12 @@ jobs:
       - name: Backup existing .env.dev file
         working-directory: ./estime-api
         run: |
-          mv .env.dev .env.before || true
+          if [ -f .env.dev ]; then
+            echo "Found .env.dev, backing up to .env.before"
+            mv .env.dev .env.before
+          else
+            echo "No .env.dev file found, skipping backup."
+          fi
 
       - name: Create env file for Docker Compose
         run: |

--- a/.github/workflows/CD-dev.yml
+++ b/.github/workflows/CD-dev.yml
@@ -92,6 +92,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Backup existing .env.dev file
+        working-directory: ./estime-api
+        run: |
+          mv .env.dev .env.before || true
+
       - name: Create env file for Docker Compose
         run: |
           printf '%s\n' "IMAGE_NAME=${{ secrets.DEV_IMAGE_NAME }}" > .env

--- a/.github/workflows/CD-prod.yml
+++ b/.github/workflows/CD-prod.yml
@@ -95,7 +95,12 @@ jobs:
       - name: Backup existing .env.prod file
         working-directory: ./estime-api
         run: |
-          mv .env.prod .env.before || true
+          if [ -f .env.prod ]; then
+            echo "Found .env.prod, backing up to .env.before"
+            mv .env.prod .env.before
+          else
+            echo "No .env.prod file found, skipping backup."
+          fi
 
       - name: Create env file for Docker Compose
         run: |

--- a/.github/workflows/CD-prod.yml
+++ b/.github/workflows/CD-prod.yml
@@ -92,6 +92,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Backup existing .env.prod file
+        working-directory: ./estime-api
+        run: |
+          mv .env.prod .env.before || true
+
       - name: Create env file for Docker Compose
         run: |
           printf '%s\n' "IMAGE_NAME=${{ secrets.PROD_IMAGE_NAME }}" > .env

--- a/.github/workflows/CD-prod.yml
+++ b/.github/workflows/CD-prod.yml
@@ -96,8 +96,8 @@ jobs:
         working-directory: ./estime-api
         run: |
           if [ -f .env.prod ]; then
-            echo "Found .env.prod, backing up to .env.before"
-            mv .env.prod .env.before
+            echo "Found .env.prod, backing up to .env.prod.before"
+            mv .env.prod .env.prod.before
           else
             echo "No .env.prod file found, skipping backup."
           fi


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #437 

## 📝 작업 내용

CD 스크립트에 기존 .env 파일을 .env.before로 백업하는 스크립트를 추가하였습니다.


### .env 파일 백업 동작 흐름
```yaml
      - name: Backup existing .env.dev file
        working-directory: ./estime-api
        run: |
          if [ -f .env.dev ]; then # 환경 변수 파일이 있으면
            echo "Found .env.dev, backing up to .env.before" 
            mv .env.dev .env.before # .env.before로 이름 변경
          else # 없으면
            echo "No .env.dev file found, skipping backup." # 로그 출력 후 종료
          fi
```

## 💬 리뷰 요구사항
