### PR TITLE
prod rollback 스크립트 추가

### DIFF
--- a/.github/workflows/rollback-prod.yml
+++ b/.github/workflows/rollback-prod.yml
@@ -1,5 +1,10 @@
 name: Rollback Prod
 
+# 배포와 롤백 작업을 동시에 진행하지 못하도록 방지
+concurrency:
+  group: be-prod
+  cancel-in-progress: false
+
 on:
   workflow_dispatch:
     inputs:
@@ -37,11 +42,22 @@ jobs:
           docker compose -f docker-compose.prod.yml pull api
           docker compose -f docker-compose.prod.yml up -d --force-recreate
 
-      - name: 실행 중인 컨테이너 상태 확인
+      - name: 롤백 후 애플리케이션 상태 확인
         run: |
-          echo "Waiting 10 seconds for containers to stabilize..."
-          sleep 10
+          echo "Waiting up to 60 seconds for application to be healthy..."
+          for i in {1..12}; do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/actuator/health)
+            if [ "$STATUS" -eq 200 ]; then
+              echo "Application is healthy!"
+              docker ps -a
+              exit 0
+            fi
+            echo "Attempt $i: Application not ready yet (Status: $STATUS). Retrying in 5 seconds..."
+            sleep 5
+          done
+          echo "Health check failed after 60 seconds."
           docker ps -a
+          exit 1 # 워크플로우 실패 처리
 
       - name: 사용하지 않는 Docker 리소스 정리
         if: always()

--- a/.github/workflows/rollback-prod.yml
+++ b/.github/workflows/rollback-prod.yml
@@ -1,0 +1,48 @@
+name: Rollback Prod
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: '롤백 시킬 git tag version을 입력하세요. (e.g. v1.0.0-be)'
+        required: true
+        type: string
+
+jobs:
+  rollback:
+    runs-on: [ self-hosted, estime-prod ]
+    steps:
+      - name: 특정 tag의 repo checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.version }}
+
+      - name: Docker Compose용 .env 파일 생성
+        run: |
+          cat << EOF > .env
+          IMAGE_NAME=${{ secrets.PROD_IMAGE_NAME }}
+          IMAGE_TAG=${{ github.event.inputs.version }}
+          EOF
+
+      - name: Spring Boot용 .env.prod 파일 생성
+        working-directory: ./estime-api
+        run: |
+          cat <<EOF > .env.prod
+          ${{ secrets.ENV_PROD }}
+          EOF
+
+      - name: Docker Compose를 사용하여 롤백 진행
+        run: |
+          echo "Rolling back to version: ${{ github.event.inputs.version }}"
+          docker compose -f docker-compose.prod.yml pull api
+          docker compose -f docker-compose.prod.yml up -d --force-recreate
+
+      - name: 실행 중인 컨테이너 상태 확인
+        run: |
+          echo "Waiting 10 seconds for containers to stabilize..."
+          sleep 10
+          docker ps -a
+
+      - name: 사용하지 않는 Docker 리소스 정리
+        if: always()
+        run: docker system prune -a -f


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #460

## 📝 작업 내용

프로덕션 서버 장애 발생 시, 특정 버전으로 되돌릴 수 있는 수동 롤백 기능을 추가했습니다.

GitHub Actions의 workflow_dispatch를 통해 웹 UI에서 직접 실행할 수 있습니다. 롤백 담당자는 되돌리고 싶은 버전 태그(예: v1.0.0-be)를 입력하면, 해당 버전의 애플리케이션으로 롤백할 수 있습니다.

## 💬 리뷰 요구사항
이해가 잘 안되는 부분이 있으시거나 추가적으로 고려해야 할 요소가 있으시다면 언제든 말씀해주세요!