### PR TITLE
Room, ParticipantName 길이 제한 예외 처리

### DIFF
--- a/estime-api/src/main/java/com/estime/common/exception/domain/InvalidLengthException.java
+++ b/estime-api/src/main/java/com/estime/common/exception/domain/InvalidLengthException.java
@@ -1,0 +1,24 @@
+package com.estime.common.exception.domain;
+
+import com.estime.common.DomainTerm;
+import com.estime.common.exception.util.ExceptionMessageFormatter;
+
+public class InvalidLengthException extends DomainException {
+
+    public InvalidLengthException(final DomainTerm term, final Object... params) {
+        super(
+                buildLogMessage(term, params),
+                buildUserMessage(term)
+        );
+    }
+
+    private static String buildLogMessage(final DomainTerm term, final Object... params) {
+        return ExceptionMessageFormatter.format(
+                "Invalid length for %s.", term.name(), params
+        );
+    }
+
+    private static String buildUserMessage(final DomainTerm term) {
+        return "%s의 길이가 올바르지 않습니다.".formatted(term.label());
+    }
+}

--- a/estime-api/src/main/java/com/estime/room/domain/Room.java
+++ b/estime-api/src/main/java/com/estime/room/domain/Room.java
@@ -3,6 +3,7 @@ package com.estime.room.domain;
 import com.estime.common.BaseEntity;
 import com.estime.common.DomainTerm;
 import com.estime.common.exception.domain.DeadlineOverdueException;
+import com.estime.common.exception.domain.InvalidLengthException;
 import com.estime.common.exception.domain.PastNotAllowedException;
 import com.estime.common.exception.domain.UnavailableSlotException;
 import com.estime.common.util.Validator;
@@ -36,6 +37,8 @@ import lombok.ToString;
 @Getter
 @ToString
 public class Room extends BaseEntity {
+
+    private static final int TITLE_MAX_LENGTH = 20;
 
     @Column(name = "session", nullable = false)
     @Convert(converter = RoomSessionConverter.class)
@@ -73,6 +76,7 @@ public class Room extends BaseEntity {
             final DateTimeSlot deadline
     ) {
         validateNull(title, availableDateSlots, availableTimeSlots, deadline);
+        validateTitle(title);
         validateDeadline(deadline);
         return new Room(
                 RoomSession.generate(),
@@ -95,6 +99,12 @@ public class Room extends BaseEntity {
                 .add("availableTimeSlots", availableTimeSlots)
                 .add("deadline", deadline)
                 .validateNull();
+    }
+
+    private static void validateTitle(final String title) {
+        if (title.length() > TITLE_MAX_LENGTH) {
+            throw new InvalidLengthException(DomainTerm.ROOM, title);
+        }
     }
 
     private static void validateDeadline(final DateTimeSlot deadline) {

--- a/estime-api/src/main/java/com/estime/room/domain/Room.java
+++ b/estime-api/src/main/java/com/estime/room/domain/Room.java
@@ -102,7 +102,7 @@ public class Room extends BaseEntity {
     }
 
     private static void validateTitle(final String title) {
-        if (title.length() > TITLE_MAX_LENGTH) {
+        if (title.isBlank() || title.length() > TITLE_MAX_LENGTH) {
             throw new InvalidLengthException(DomainTerm.ROOM, title);
         }
     }

--- a/estime-api/src/main/java/com/estime/room/domain/participant/Participant.java
+++ b/estime-api/src/main/java/com/estime/room/domain/participant/Participant.java
@@ -44,7 +44,7 @@ public class Participant extends BaseEntity {
     }
 
     private static void validateName(final String name) {
-        if (name.length() > NAME_MAX_LENGTH) {
+        if (name.isBlank() || name.length() > NAME_MAX_LENGTH) {
             throw new InvalidLengthException(DomainTerm.PARTICIPANT, name);
         }
     }

--- a/estime-api/src/main/java/com/estime/room/domain/participant/Participant.java
+++ b/estime-api/src/main/java/com/estime/room/domain/participant/Participant.java
@@ -19,7 +19,7 @@ import lombok.ToString;
 @ToString
 public class Participant extends BaseEntity {
 
-    private static final int NAME_MAX_LENGTH = 10;
+    private static final int NAME_MAX_LENGTH = 12;
 
     @Column(name = "room_id", nullable = false)
     private Long roomId;

--- a/estime-api/src/main/java/com/estime/room/domain/participant/Participant.java
+++ b/estime-api/src/main/java/com/estime/room/domain/participant/Participant.java
@@ -1,6 +1,8 @@
 package com.estime.room.domain.participant;
 
 import com.estime.common.BaseEntity;
+import com.estime.common.DomainTerm;
+import com.estime.common.exception.domain.InvalidLengthException;
 import com.estime.common.util.Validator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -17,6 +19,8 @@ import lombok.ToString;
 @ToString
 public class Participant extends BaseEntity {
 
+    private static final int NAME_MAX_LENGTH = 10;
+
     @Column(name = "room_id", nullable = false)
     private Long roomId;
 
@@ -28,6 +32,7 @@ public class Participant extends BaseEntity {
             final String name
     ) {
         validateNull(roomId, name);
+        validateName(name);
         return new Participant(roomId, name);
     }
 
@@ -36,5 +41,11 @@ public class Participant extends BaseEntity {
                 .add("roomId", roomId)
                 .add("name", name)
                 .validateNull();
+    }
+
+    private static void validateName(final String name) {
+        if (name.length() > NAME_MAX_LENGTH) {
+            throw new InvalidLengthException(DomainTerm.PARTICIPANT, name);
+        }
     }
 }

--- a/estime-api/src/test/java/com/estime/room/domain/RoomTest.java
+++ b/estime-api/src/test/java/com/estime/room/domain/RoomTest.java
@@ -115,4 +115,20 @@ class RoomTest {
                 futureDeadline
         )).doesNotThrowAnyException();
     }
+
+    @DisplayName("제목이 빈 문자열이면 InvalidLengthException이 발생한다")
+    @Test
+    void validateTitle_blank_throwsException() {
+        // given
+        String blankTitle = "   ";
+
+        // when & then
+        assertThatThrownBy(() -> Room.withoutId(
+                blankTitle,
+                List.of(dateSlot),
+                List.of(timeSlot),
+                futureDeadline
+        )).isInstanceOf(InvalidLengthException.class)
+          .hasMessageContaining(DomainTerm.ROOM.name());
+    }
 }

--- a/estime-api/src/test/java/com/estime/room/domain/RoomTest.java
+++ b/estime-api/src/test/java/com/estime/room/domain/RoomTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.estime.common.DomainTerm;
 import com.estime.common.exception.domain.DeadlineOverdueException;
+import com.estime.common.exception.domain.InvalidLengthException;
 import com.estime.common.exception.domain.PastNotAllowedException;
 import com.estime.room.domain.slot.vo.DateSlot;
 import com.estime.room.domain.slot.vo.DateTimeSlot;
@@ -82,5 +83,36 @@ class RoomTest {
         );
         assertThatCode(() -> room.ensureDeadlineNotPassed(now))
                 .doesNotThrowAnyException();
+    }
+
+    @DisplayName("제목이 최대 길이(20)를 초과하면 InvalidLengthException이 발생한다")
+    @Test
+    void validateTitle_exceedMaxLength_throwsException() {
+        // given
+        String invalidTitle = "제목이 너무 길어서 예외가 발생하는 경우입니다";
+
+        // when & then
+        assertThatThrownBy(() -> Room.withoutId(
+                invalidTitle,
+                List.of(dateSlot),
+                List.of(timeSlot),
+                futureDeadline
+        )).isInstanceOf(InvalidLengthException.class)
+          .hasMessageContaining(DomainTerm.ROOM.name());
+    }
+
+    @DisplayName("제목이 최대 길이(20)와 같으면 예외가 발생하지 않는다")
+    @Test
+    void validateTitle_exactMaxLength_success() {
+        // given
+        String exactLengthTitle = "이십글자제목입니다이십글자";
+
+        // when & then
+        assertThatCode(() -> Room.withoutId(
+                exactLengthTitle,
+                List.of(dateSlot),
+                List.of(timeSlot),
+                futureDeadline
+        )).doesNotThrowAnyException();
     }
 }

--- a/estime-api/src/test/java/com/estime/room/domain/participant/ParticipantTest.java
+++ b/estime-api/src/test/java/com/estime/room/domain/participant/ParticipantTest.java
@@ -32,4 +32,16 @@ class ParticipantTest {
         assertThatCode(() -> Participant.withoutId(1L, exactLengthName))
                 .doesNotThrowAnyException();
     }
+
+    @DisplayName("이름이 빈 문자열이면 InvalidLengthException이 발생한다")
+    @Test
+    void validateName_blank_throwsException() {
+        // given
+        String blankName = "   ";
+
+        // when & then
+        assertThatThrownBy(() -> Participant.withoutId(1L, blankName))
+                .isInstanceOf(InvalidLengthException.class)
+                .hasMessageContaining(DomainTerm.PARTICIPANT.name());
+    }
 }

--- a/estime-api/src/test/java/com/estime/room/domain/participant/ParticipantTest.java
+++ b/estime-api/src/test/java/com/estime/room/domain/participant/ParticipantTest.java
@@ -1,0 +1,35 @@
+package com.estime.room.domain.participant;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.estime.common.DomainTerm;
+import com.estime.common.exception.domain.InvalidLengthException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ParticipantTest {
+
+    @DisplayName("이름이 최대 길이(10)를 초과하면 InvalidLengthException이 발생한다")
+    @Test
+    void validateName_exceedMaxLength_throwsException() {
+        // given
+        String invalidName = "이름이너무길어서예외가발생합니다";
+
+        // when & then
+        assertThatThrownBy(() -> Participant.withoutId(1L, invalidName))
+                .isInstanceOf(InvalidLengthException.class)
+                .hasMessageContaining(DomainTerm.PARTICIPANT.name());
+    }
+
+    @DisplayName("이름이 최대 길이(10)와 같으면 예외가 발생하지 않는다")
+    @Test
+    void validateName_exactMaxLength_success() {
+        // given
+        String exactLengthName = "열글자이름입니다";
+
+        // when & then
+        assertThatCode(() -> Participant.withoutId(1L, exactLengthName))
+                .doesNotThrowAnyException();
+    }
+}

--- a/estime-api/src/test/java/com/estime/room/domain/participant/ParticipantTest.java
+++ b/estime-api/src/test/java/com/estime/room/domain/participant/ParticipantTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 
 class ParticipantTest {
 
-    @DisplayName("이름이 최대 길이(10)를 초과하면 InvalidLengthException이 발생한다")
+    @DisplayName("이름이 최대 길이(12)를 초과하면 InvalidLengthException이 발생한다")
     @Test
     void validateName_exceedMaxLength_throwsException() {
         // given
@@ -22,11 +22,11 @@ class ParticipantTest {
                 .hasMessageContaining(DomainTerm.PARTICIPANT.name());
     }
 
-    @DisplayName("이름이 최대 길이(10)와 같으면 예외가 발생하지 않는다")
+    @DisplayName("이름이 최대 길이(12)와 같으면 예외가 발생하지 않는다")
     @Test
     void validateName_exactMaxLength_success() {
         // given
-        String exactLengthName = "열글자이름입니다";
+        String exactLengthName = "열두글자이름입니다열두글";
 
         // when & then
         assertThatCode(() -> Participant.withoutId(1L, exactLengthName))


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #407 

## 📝 작업 내용

- 커스텀 예외 구현
- 방 생성 로직 title 20자 제한 예외처리 적용
- 참가자 name 12 자 제한 예외처리 적용
- String 빈 공백 예외처리 적용
- 경계값 테스트 구현

## 💬 리뷰 요구사항