### PR TITLE
prod 서버 rollback 스크립트 추가

### DIFF
--- a/.github/workflows/rollback-prod.yml
+++ b/.github/workflows/rollback-prod.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   rollback:
+    environment: be-prod
     runs-on: [ self-hosted, estime-prod ]
 
     steps:

--- a/.github/workflows/rollback-prod.yml
+++ b/.github/workflows/rollback-prod.yml
@@ -1,0 +1,103 @@
+name: Rollback Prod
+
+# 롤백 작업이 새로운 CD 작업에 의해 중단되지 않도록 보장
+concurrency:
+  group: be-prod
+  cancel-in-progress: false
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'rollback 시킬 git tag version을 입력하세요. (e.g. v1.0.0-be)'
+        required: true
+        type: string
+
+jobs:
+  rollback:
+    runs-on: [ self-hosted, estime-prod ]
+
+    steps:
+      - name: rollback 시점의 .env.prod 파일 백업 # rollback 원인 분석 목적
+        run: |
+          CURRENT_VERSION="unknown"
+          if [ -f ${{ github.workspace }}/.env ]; then
+            CURRENT_VERSION=$(grep IMAGE_TAG ${{ github.workspace }}/.env | cut -d '=' -f2)
+            if [ -z "$CURRENT_VERSION" ]; then
+              CURRENT_VERSION="tag-not-found"
+            fi
+          fi
+
+          BACKUP_DIR=~/env_backups/rollbacked
+          mkdir -p "$BACKUP_DIR"
+          if [ -f ${{ github.workspace }}/estime-api/.env.prod ]; then
+            BACKUP_NAME=".env.rollbacked_from_${CURRENT_VERSION}_to_${{ github.event.inputs.version }}.$(date +%Y%m%d%H%M%S)"
+            echo "Backing up the current .env.prod to $BACKUP_DIR/$BACKUP_NAME"
+            mv ${{ github.workspace }}/estime-api/.env.prod "$BACKUP_DIR/$BACKUP_NAME"
+          else
+            echo "No .env.prod file found to back up."
+          fi
+
+      - name: 특정 tag의 repository checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.version }}
+          fetch-depth: 0
+
+      - name: rollback 대상 tag가 be/prod branch에 있는지 검증
+        run: |
+          git fetch origin be/prod
+          if git merge-base --is-ancestor HEAD origin/be/prod; then
+            echo "Rollback target tag is on the be/prod branch. Proceeding."
+          else
+            echo "Error: The tag you are trying to roll back to is not on the be/prod branch."
+            exit 1
+          fi
+
+      - name: Docker Compose용 .env 파일 생성
+        run: |
+          cat <<EOF > .env
+          IMAGE_NAME=${{ secrets.PROD_IMAGE_NAME }}
+          IMAGE_TAG=${{ github.event.inputs.version }}
+          EOF
+
+      - name: Application용 .env.prod 파일 생성
+        working-directory: ./estime-api
+        run: |
+          cat <<EOF > .env.prod
+          ${{ secrets.ENV_PROD }}
+          EOF
+
+      - name: Docker Compose를 사용하여 rollback 진행
+        run: |
+          echo "Rolling back to version: ${{ github.event.inputs.version }}"
+          docker compose -f docker-compose.prod.yml pull api
+          docker compose -f docker-compose.prod.yml up -d --force-recreate
+
+      - name: rollback 후 application 상태 확인
+        run: |
+          echo "Waiting 10 seconds for application to start up..."
+          sleep 10
+          echo "Starting health checks..."
+          for i in {1..12}; do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/actuator/health || true)
+            if [ "$STATUS" -eq 200 ]; then
+              echo "✅ Rollback successful! Application is healthy."
+              docker ps -a
+              exit 0 # 롤백 성공
+            fi
+            echo "Attempt $i: Application not ready yet (Status: $STATUS). Retrying in 5 seconds..."
+            sleep 5
+          done
+          
+          echo "❌ Health check failed after 60 seconds."
+          echo "==== docker container status ===="
+          docker ps -a
+          echo "==== docker container logs (api) ===="
+          docker logs $(docker ps --filter "name=api" --format "{{.ID}}") || true
+          
+          exit 1 # 롤백 실패
+
+      - name: 사용하지 않는 Docker resource 정리
+        if: always()
+        run: docker system prune -a -f


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #460

## 📝 작업 내용

프로덕션 서버 장애 발생 시, 특정 버전으로 되돌릴 수 있는 수동 롤백 기능을 추가했습니다.

GitHub Actions의 workflow_dispatch를 통해 웹 UI에서 직접 실행할 수 있습니다. 롤백 담당자는 되돌리고 싶은 버전 태그(예: v1.0.0-be)를 입력하면, 해당 버전의 애플리케이션으로 롤백할 수 있습니다.

프로덕션 장애 시, GitHub Actions UI에서 특정 버전 태그를 입력하여 수동으로 롤백을 실행하는 워크플로우를 추가합니다.

## 주의 사항

**해당 스크립트가 기본 브랜치에 있어야 사용 가능하다고 해서 main으로 merge하고자 합니다!!**

## 특이 사항

백업 → 검증 → 실행의 순서로 동작합니다.

(A) 백업: 롤백을 시작하기 직전, 실패 원인 분석을 위해 현재 서버의 .env.prod 파일을 먼저 백업

(B) 검증: 잘못된 버전으로 롤백하는 것을 막기 위해, 롤백하려는 태그가 be/prod 브랜치에 속해 있는지 검증

(C) 실행 및 확인: 모든 검증을 통과하면 롤백을 실행하고, Health Check를 통해 애플리케이션이 실제로 정상 구동되었는지 최종 확인

#### .env 롤백 백업 파일명 및 위치

롤백 시 백업되는 .env.prod 파일은 장애 원인 분석을 위한 중요한 증거 자료로 활용되며, 아래 규칙에 따라 저장됩니다.

저장 위치: ~/env_backups/rollbacked/
파일 이름 형식: .env.rollbacked_from_[현재 버전]_to_[롤백 대상 버전].[타임스탬프]

- 케이스별 예시:
  - 정상: .env.rollbacked_from_v1.2.3-be_to_v1.2.2-be.20250821203600
  - .env 파일이 없는 경우: .env.rollbacked_from_unknown_to_v1.2.2-be.20250821203600
  - IMAGE_TAG 키가 없는 경우: .env.rollbacked_from_tag-not-found_to_v1.2.2-be.20250821203600

## 💬 리뷰 요구사항
이해가 잘 안되는 부분이 있으시거나 추가적으로 고려해야 할 요소가 있으시다면 언제든 말씀해주세요!