### PR TITLE
[BUILD FAIL] ParticipantName 값 객체로 변경 

### DIFF
--- a/estime-api/src/main/java/com/estime/room/application/dto/input/ParticipantCreateInput.java
+++ b/estime-api/src/main/java/com/estime/room/application/dto/input/ParticipantCreateInput.java
@@ -6,9 +6,9 @@ import com.estime.room.domain.vo.RoomSession;
 
 public record ParticipantCreateInput(
         RoomSession session,
-        ParticipantName participantName
+        ParticipantName name
 ) {
     public Participant toEntity(final Long roomId) {
-        return Participant.withoutId(roomId, participantName);
+        return Participant.withoutId(roomId, name);
     }
 }

--- a/estime-api/src/main/java/com/estime/room/application/dto/input/ParticipantCreateInput.java
+++ b/estime-api/src/main/java/com/estime/room/application/dto/input/ParticipantCreateInput.java
@@ -1,11 +1,12 @@
 package com.estime.room.application.dto.input;
 
 import com.estime.room.domain.participant.Participant;
+import com.estime.room.domain.participant.vo.ParticipantName;
 import com.estime.room.domain.vo.RoomSession;
 
 public record ParticipantCreateInput(
         RoomSession session,
-        String participantName
+        ParticipantName participantName
 ) {
     public Participant toEntity(final Long roomId) {
         return Participant.withoutId(roomId, participantName);

--- a/estime-api/src/main/java/com/estime/room/application/dto/input/VotesFindInput.java
+++ b/estime-api/src/main/java/com/estime/room/application/dto/input/VotesFindInput.java
@@ -6,7 +6,7 @@ import com.github.f4b6a3.tsid.Tsid;
 
 public record VotesFindInput(
         RoomSession session,
-        ParticipantName participantName
+        ParticipantName name
 ) {
 
     public static VotesFindInput of(Tsid roomSession, String participantName) {

--- a/estime-api/src/main/java/com/estime/room/application/dto/input/VotesFindInput.java
+++ b/estime-api/src/main/java/com/estime/room/application/dto/input/VotesFindInput.java
@@ -1,14 +1,18 @@
 package com.estime.room.application.dto.input;
 
+import com.estime.room.domain.participant.vo.ParticipantName;
 import com.estime.room.domain.vo.RoomSession;
 import com.github.f4b6a3.tsid.Tsid;
 
 public record VotesFindInput(
         RoomSession session,
-        String participantName
+        ParticipantName participantName
 ) {
 
     public static VotesFindInput of(Tsid roomSession, String participantName) {
-        return new VotesFindInput(RoomSession.from(roomSession), participantName);
+        return new VotesFindInput(
+                RoomSession.from(roomSession),
+                ParticipantName.from(participantName)
+        );
     }
 }

--- a/estime-api/src/main/java/com/estime/room/application/dto/input/VotesOutput.java
+++ b/estime-api/src/main/java/com/estime/room/application/dto/input/VotesOutput.java
@@ -6,14 +6,11 @@ import com.estime.room.domain.participant.vote.Votes;
 import java.util.List;
 
 public record VotesOutput(
-        ParticipantName participantName,
+        ParticipantName name,
         List<Vote> votes
 ) {
 
-    public static VotesOutput from(final ParticipantName participantName, final Votes votes) {
-        return new VotesOutput(
-                participantName,
-                votes.getSortedVotes()
-        );
+    public static VotesOutput from(final ParticipantName name, final Votes votes) {
+        return new VotesOutput(name, votes.getSortedVotes());
     }
 }

--- a/estime-api/src/main/java/com/estime/room/application/dto/input/VotesOutput.java
+++ b/estime-api/src/main/java/com/estime/room/application/dto/input/VotesOutput.java
@@ -1,15 +1,16 @@
 package com.estime.room.application.dto.input;
 
+import com.estime.room.domain.participant.vo.ParticipantName;
 import com.estime.room.domain.participant.vote.Vote;
 import com.estime.room.domain.participant.vote.Votes;
 import java.util.List;
 
 public record VotesOutput(
-        String participantName,
+        ParticipantName participantName,
         List<Vote> votes
 ) {
 
-    public static VotesOutput from(final String participantName, final Votes votes) {
+    public static VotesOutput from(final ParticipantName participantName, final Votes votes) {
         return new VotesOutput(
                 participantName,
                 votes.getSortedVotes()

--- a/estime-api/src/main/java/com/estime/room/application/dto/input/VotesUpdateInput.java
+++ b/estime-api/src/main/java/com/estime/room/application/dto/input/VotesUpdateInput.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public record VotesUpdateInput(
         RoomSession session,
-        ParticipantName participantName,
+        ParticipantName name,
         List<DateTimeSlot> dateTimeSlots
 ) {
 

--- a/estime-api/src/main/java/com/estime/room/application/dto/input/VotesUpdateInput.java
+++ b/estime-api/src/main/java/com/estime/room/application/dto/input/VotesUpdateInput.java
@@ -1,5 +1,6 @@
 package com.estime.room.application.dto.input;
 
+import com.estime.room.domain.participant.vo.ParticipantName;
 import com.estime.room.domain.participant.vote.Vote;
 import com.estime.room.domain.slot.vo.DateTimeSlot;
 import com.estime.room.domain.vo.RoomSession;
@@ -7,7 +8,7 @@ import java.util.List;
 
 public record VotesUpdateInput(
         RoomSession session,
-        String participantName,
+        ParticipantName participantName,
         List<DateTimeSlot> dateTimeSlots
 ) {
 

--- a/estime-api/src/main/java/com/estime/room/application/dto/output/DateTimeSlotStatisticOutput.java
+++ b/estime-api/src/main/java/com/estime/room/application/dto/output/DateTimeSlotStatisticOutput.java
@@ -1,5 +1,6 @@
 package com.estime.room.application.dto.output;
 
+import com.estime.room.domain.participant.vo.ParticipantName;
 import com.estime.room.domain.slot.vo.DateTimeSlot;
 import java.util.List;
 
@@ -10,7 +11,7 @@ public record DateTimeSlotStatisticOutput(
 
     public record DateTimeParticipantsOutput(
             DateTimeSlot dateTimeSlot,
-            List<String> participantNames
+            List<ParticipantName> participantNames
     ) {
     }
 }

--- a/estime-api/src/main/java/com/estime/room/application/dto/output/ParticipantCreateOutput.java
+++ b/estime-api/src/main/java/com/estime/room/application/dto/output/ParticipantCreateOutput.java
@@ -1,9 +1,10 @@
 package com.estime.room.application.dto.output;
 
 import com.estime.room.domain.participant.Participant;
+import com.estime.room.domain.participant.vo.ParticipantName;
 
 public record ParticipantCreateOutput(
-        String name
+        ParticipantName name
 ) {
 
     public static ParticipantCreateOutput from(final Participant participant) {

--- a/estime-api/src/main/java/com/estime/room/application/service/RoomApplicationService.java
+++ b/estime-api/src/main/java/com/estime/room/application/service/RoomApplicationService.java
@@ -126,9 +126,9 @@ public class RoomApplicationService {
     @Transactional(readOnly = true)
     public VotesOutput getParticipantVotesBySessionAndParticipantName(final VotesFindInput input) {
         final Long roomId = obtainRoomIdBySession(input.session());
-        final Long participantId = obtainParticipantIdByRoomIdAndName(roomId, input.participantName());
+        final Long participantId = obtainParticipantIdByRoomIdAndName(roomId, input.name());
         final Votes votes = voteRepository.findAllByParticipantId(participantId);
-        return VotesOutput.from(input.participantName(), votes);
+        return VotesOutput.from(input.name(), votes);
     }
 
     @Transactional
@@ -167,7 +167,7 @@ public class RoomApplicationService {
 
         room.ensureDeadlineNotPassed(LocalDateTime.now());
 
-        final boolean isDuplicateName = participantRepository.existsByRoomIdAndName(roomId, input.participantName());
+        final boolean isDuplicateName = participantRepository.existsByRoomIdAndName(roomId, input.name());
         if (!isDuplicateName) {
             participantRepository.save(input.toEntity(roomId));
         }
@@ -185,8 +185,8 @@ public class RoomApplicationService {
                 .orElseThrow(() -> new NotFoundException(DomainTerm.ROOM, session));
     }
 
-    private Long obtainParticipantIdByRoomIdAndName(final Long roomId, final ParticipantName participantName) {
-        return participantRepository.findIdByRoomIdAndName(roomId, participantName)
-                .orElseThrow(() -> new NotFoundException(DomainTerm.PARTICIPANT, roomId, participantName));
+    private Long obtainParticipantIdByRoomIdAndName(final Long roomId, final ParticipantName name) {
+        return participantRepository.findIdByRoomIdAndName(roomId, name)
+                .orElseThrow(() -> new NotFoundException(DomainTerm.PARTICIPANT, roomId, name));
     }
 }

--- a/estime-api/src/main/java/com/estime/room/application/service/RoomApplicationService.java
+++ b/estime-api/src/main/java/com/estime/room/application/service/RoomApplicationService.java
@@ -134,7 +134,7 @@ public class RoomApplicationService {
     @Transactional
     public VotesOutput updateParticipantVotes(final VotesUpdateInput input) {
         final Room room = obtainRoomBySession(input.session());
-        final Long participantId = obtainParticipantIdByRoomIdAndName(room.getId(), input.participantName());
+        final Long participantId = obtainParticipantIdByRoomIdAndName(room.getId(), input.name());
 
         room.ensureDeadlineNotPassed(LocalDateTime.now());
         room.ensureAvailableDateTimeSlots(input.dateTimeSlots());
@@ -157,7 +157,7 @@ public class RoomApplicationService {
             }
         });
 
-        return VotesOutput.from(input.participantName(), updatedVotes);
+        return VotesOutput.from(input.name(), updatedVotes);
     }
 
     @Transactional

--- a/estime-api/src/main/java/com/estime/room/application/service/RoomApplicationService.java
+++ b/estime-api/src/main/java/com/estime/room/application/service/RoomApplicationService.java
@@ -20,6 +20,7 @@ import com.estime.room.domain.Room;
 import com.estime.room.domain.RoomRepository;
 import com.estime.room.domain.participant.Participant;
 import com.estime.room.domain.participant.ParticipantRepository;
+import com.estime.room.domain.participant.vo.ParticipantName;
 import com.estime.room.domain.participant.vote.VoteRepository;
 import com.estime.room.domain.participant.vote.Votes;
 import com.estime.room.domain.platform.Platform;
@@ -106,7 +107,7 @@ public class RoomApplicationService {
                 .flatMap(Collection::stream)
                 .collect(Collectors.toSet());
 
-        final Map<Long, String> idToName = participantRepository.findAllByIdIn(participantsIds).stream()
+        final Map<Long, ParticipantName> idToName = participantRepository.findAllByIdIn(participantsIds).stream()
                 .collect(Collectors.toMap(Participant::getId, Participant::getName));
 
         return new DateTimeSlotStatisticOutput(
@@ -146,7 +147,8 @@ public class RoomApplicationService {
 
         final Tsid roomSession = input.session().getValue();
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-            @Override public void afterCommit() {
+            @Override
+            public void afterCommit() {
                 try {
                     sseService.sendSseByRoomSession(roomSession, "vote-changed");
                 } catch (final Exception e) {
@@ -183,7 +185,7 @@ public class RoomApplicationService {
                 .orElseThrow(() -> new NotFoundException(DomainTerm.ROOM, session));
     }
 
-    private Long obtainParticipantIdByRoomIdAndName(final Long roomId, final String participantName) {
+    private Long obtainParticipantIdByRoomIdAndName(final Long roomId, final ParticipantName participantName) {
         return participantRepository.findIdByRoomIdAndName(roomId, participantName)
                 .orElseThrow(() -> new NotFoundException(DomainTerm.PARTICIPANT, roomId, participantName));
     }

--- a/estime-api/src/main/java/com/estime/room/domain/participant/Participant.java
+++ b/estime-api/src/main/java/com/estime/room/domain/participant/Participant.java
@@ -1,52 +1,46 @@
 package com.estime.room.domain.participant;
 
 import com.estime.common.BaseEntity;
-import com.estime.common.DomainTerm;
-import com.estime.common.exception.domain.InvalidLengthException;
 import com.estime.common.util.Validator;
+import com.estime.room.domain.participant.infrastructure.converter.ParticipantNameConverter;
+import com.estime.room.domain.participant.vo.ParticipantName;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import lombok.experimental.FieldNameConstants;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 @ToString
+@FieldNameConstants
 public class Participant extends BaseEntity {
-
-    private static final int NAME_MAX_LENGTH = 12;
 
     @Column(name = "room_id", nullable = false)
     private Long roomId;
 
     @Column(name = "name", nullable = false)
-    private String name;
+    @Convert(converter = ParticipantNameConverter.class)
+    private ParticipantName name;
 
     public static Participant withoutId(
             final Long roomId,
-            final String name
+            final ParticipantName name
     ) {
         validateNull(roomId, name);
-        final String trimmedName = name.trim();
-        validateName(trimmedName);
-        return new Participant(roomId, trimmedName);
+        return new Participant(roomId, name);
     }
 
-    private static void validateNull(final Long roomId, final String name) {
+    private static void validateNull(final Long roomId, final ParticipantName name) {
         Validator.builder()
-                .add("roomId", roomId)
-                .add("name", name)
+                .add(Fields.roomId, roomId)
+                .add(Fields.name, name)
                 .validateNull();
-    }
-
-    private static void validateName(final String trimmedName) {
-        if (trimmedName.isBlank() || trimmedName.length() > NAME_MAX_LENGTH) {
-            throw new InvalidLengthException(DomainTerm.PARTICIPANT, trimmedName);
-        }
     }
 }

--- a/estime-api/src/main/java/com/estime/room/domain/participant/ParticipantRepository.java
+++ b/estime-api/src/main/java/com/estime/room/domain/participant/ParticipantRepository.java
@@ -1,5 +1,6 @@
 package com.estime.room.domain.participant;
 
+import com.estime.room.domain.participant.vo.ParticipantName;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -8,9 +9,9 @@ public interface ParticipantRepository {
 
     Participant save(Participant participant);
 
-    boolean existsByRoomIdAndName(Long roomId, String name);
+    boolean existsByRoomIdAndName(Long roomId, ParticipantName name);
 
-    Optional<Long> findIdByRoomIdAndName(Long roomId, String name);
+    Optional<Long> findIdByRoomIdAndName(Long roomId, ParticipantName name);
 
     List<Long> findIdsByRoomId(Long roomId);
 

--- a/estime-api/src/main/java/com/estime/room/domain/participant/infrastructure/converter/ParticipantNameConverter.java
+++ b/estime-api/src/main/java/com/estime/room/domain/participant/infrastructure/converter/ParticipantNameConverter.java
@@ -8,8 +8,8 @@ import jakarta.persistence.Converter;
 public class ParticipantNameConverter implements AttributeConverter<ParticipantName, String> {
 
     @Override
-    public String convertToDatabaseColumn(final ParticipantName participantName) {
-        return participantName == null ? null : participantName.getValue();
+    public String convertToDatabaseColumn(final ParticipantName name) {
+        return name == null ? null : name.getValue();
     }
 
     @Override

--- a/estime-api/src/main/java/com/estime/room/domain/participant/infrastructure/converter/ParticipantNameConverter.java
+++ b/estime-api/src/main/java/com/estime/room/domain/participant/infrastructure/converter/ParticipantNameConverter.java
@@ -1,0 +1,19 @@
+package com.estime.room.domain.participant.infrastructure.converter;
+
+import com.estime.room.domain.participant.vo.ParticipantName;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class ParticipantNameConverter implements AttributeConverter<ParticipantName, String> {
+
+    @Override
+    public String convertToDatabaseColumn(final ParticipantName participantName) {
+        return participantName == null ? null : participantName.getValue();
+    }
+
+    @Override
+    public ParticipantName convertToEntityAttribute(final String dbData) {
+        return dbData == null ? null : ParticipantName.from(dbData);
+    }
+}

--- a/estime-api/src/main/java/com/estime/room/domain/participant/vo/ParticipantName.java
+++ b/estime-api/src/main/java/com/estime/room/domain/participant/vo/ParticipantName.java
@@ -17,15 +17,15 @@ public class ParticipantName {
 
     private String value;
 
-    public static ParticipantName from(final String name) {
-        final String trimmedName = name.trim();
+    public static ParticipantName from(final String participantName) {
+        final String trimmedName = participantName.trim();
         validate(trimmedName);
         return new ParticipantName(trimmedName);
     }
 
-    private static void validate(final String name) {
-        if (name.isBlank() || name.length() > NAME_MAX_LENGTH) {
-            throw new InvalidLengthException(DomainTerm.PARTICIPANT, name);
+    private static void validate(final String participantName) {
+        if (participantName.isBlank() || participantName.length() > NAME_MAX_LENGTH) {
+            throw new InvalidLengthException(DomainTerm.PARTICIPANT, participantName);
         }
     }
 }

--- a/estime-api/src/main/java/com/estime/room/domain/participant/vo/ParticipantName.java
+++ b/estime-api/src/main/java/com/estime/room/domain/participant/vo/ParticipantName.java
@@ -2,15 +2,18 @@ package com.estime.room.domain.participant.vo;
 
 import com.estime.common.DomainTerm;
 import com.estime.common.exception.domain.InvalidLengthException;
+import com.estime.common.util.Validator;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.experimental.FieldNameConstants;
 
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 @EqualsAndHashCode
+@FieldNameConstants
 public class ParticipantName {
 
     private static final int NAME_MAX_LENGTH = 12;
@@ -18,12 +21,19 @@ public class ParticipantName {
     private String value;
 
     public static ParticipantName from(final String participantName) {
+        validateNull(participantName);
         final String trimmedName = participantName.trim();
-        validate(trimmedName);
+        validateName(trimmedName);
         return new ParticipantName(trimmedName);
     }
 
-    private static void validate(final String participantName) {
+    private static void validateNull(final String participantName) {
+        Validator.builder()
+                .add("participantName", participantName)
+                .validateNull();
+    }
+
+    private static void validateName(final String participantName) {
         if (participantName.isBlank() || participantName.length() > NAME_MAX_LENGTH) {
             throw new InvalidLengthException(DomainTerm.PARTICIPANT, participantName);
         }

--- a/estime-api/src/main/java/com/estime/room/domain/participant/vo/ParticipantName.java
+++ b/estime-api/src/main/java/com/estime/room/domain/participant/vo/ParticipantName.java
@@ -1,0 +1,31 @@
+package com.estime.room.domain.participant.vo;
+
+import com.estime.common.DomainTerm;
+import com.estime.common.exception.domain.InvalidLengthException;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@EqualsAndHashCode
+public class ParticipantName {
+
+    private static final int NAME_MAX_LENGTH = 12;
+
+    private String value;
+
+    public static ParticipantName from(final String name) {
+        final String trimmedName = name.trim();
+        validate(trimmedName);
+        return new ParticipantName(trimmedName);
+    }
+
+    private static void validate(final String name) {
+        if (name.isBlank() || name.length() > NAME_MAX_LENGTH) {
+            throw new InvalidLengthException(DomainTerm.PARTICIPANT, name);
+        }
+    }
+}

--- a/estime-api/src/main/java/com/estime/room/infrastructure/participant/ParticipantJpaRepository.java
+++ b/estime-api/src/main/java/com/estime/room/infrastructure/participant/ParticipantJpaRepository.java
@@ -1,6 +1,7 @@
 package com.estime.room.infrastructure.participant;
 
 import com.estime.room.domain.participant.Participant;
+import com.estime.room.domain.participant.vo.ParticipantName;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -8,9 +9,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ParticipantJpaRepository extends JpaRepository<Participant, Long> {
 
-    Optional<Participant> findByRoomIdAndNameAndActiveTrue(Long roomId, String name);
+    Optional<Participant> findByRoomIdAndNameAndActiveTrue(Long roomId, ParticipantName name);
 
-    boolean existsByRoomIdAndNameAndActiveTrue(Long roomId, String name);
+    boolean existsByRoomIdAndNameAndActiveTrue(Long roomId, ParticipantName name);
 
     List<Participant> findAllByRoomIdAndActiveTrue(Long roomId);
 

--- a/estime-api/src/main/java/com/estime/room/infrastructure/participant/ParticipantRepositoryImpl.java
+++ b/estime-api/src/main/java/com/estime/room/infrastructure/participant/ParticipantRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.estime.room.infrastructure.participant;
 import com.estime.common.BaseEntity;
 import com.estime.room.domain.participant.Participant;
 import com.estime.room.domain.participant.ParticipantRepository;
+import com.estime.room.domain.participant.vo.ParticipantName;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -21,7 +22,7 @@ public class ParticipantRepositoryImpl implements ParticipantRepository {
     }
 
     @Override
-    public boolean existsByRoomIdAndName(final Long roomId, final String name) {
+    public boolean existsByRoomIdAndName(final Long roomId, final ParticipantName name) {
         return jpaRepository.existsByRoomIdAndNameAndActiveTrue(roomId, name);
     }
 
@@ -38,7 +39,7 @@ public class ParticipantRepositoryImpl implements ParticipantRepository {
     }
 
     @Override
-    public Optional<Long> findIdByRoomIdAndName(final Long roomId, final String name) {
+    public Optional<Long> findIdByRoomIdAndName(final Long roomId, final ParticipantName name) {
         return jpaRepository.findByRoomIdAndNameAndActiveTrue(roomId, name)
                 .map(Participant::getId);
     }

--- a/estime-api/src/main/java/com/estime/room/presentation/RoomController.java
+++ b/estime-api/src/main/java/com/estime/room/presentation/RoomController.java
@@ -1,14 +1,13 @@
 package com.estime.room.presentation;
 
 import com.estime.common.CustomApiResponse;
-import com.estime.room.application.dto.input.VotesOutput;
 import com.estime.room.application.dto.input.RoomSessionInput;
 import com.estime.room.application.dto.input.VotesFindInput;
+import com.estime.room.application.dto.input.VotesOutput;
 import com.estime.room.application.dto.output.DateTimeSlotStatisticOutput;
 import com.estime.room.application.dto.output.ParticipantCheckOutput;
 import com.estime.room.application.dto.output.RoomOutput;
 import com.estime.room.application.service.RoomApplicationService;
-import com.estime.room.domain.participant.vote.Votes;
 import com.estime.room.presentation.dto.request.ConnectedRoomCreateRequest;
 import com.estime.room.presentation.dto.request.ParticipantCreateRequest;
 import com.estime.room.presentation.dto.request.ParticipantVotesUpdateRequest;

--- a/estime-api/src/main/java/com/estime/room/presentation/dto/request/ParticipantCreateRequest.java
+++ b/estime-api/src/main/java/com/estime/room/presentation/dto/request/ParticipantCreateRequest.java
@@ -1,6 +1,7 @@
 package com.estime.room.presentation.dto.request;
 
 import com.estime.room.application.dto.input.ParticipantCreateInput;
+import com.estime.room.domain.participant.vo.ParticipantName;
 import com.estime.room.domain.vo.RoomSession;
 import com.github.f4b6a3.tsid.Tsid;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -11,6 +12,9 @@ public record ParticipantCreateRequest(
 ) {
 
     public ParticipantCreateInput toInput(final Tsid roomSession) {
-        return new ParticipantCreateInput(RoomSession.from(roomSession), participantName);
+        return new ParticipantCreateInput(
+                RoomSession.from(roomSession),
+                ParticipantName.from(participantName)
+        );
     }
 }

--- a/estime-api/src/main/java/com/estime/room/presentation/dto/request/ParticipantVotesUpdateRequest.java
+++ b/estime-api/src/main/java/com/estime/room/presentation/dto/request/ParticipantVotesUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.estime.room.presentation.dto.request;
 
 import com.estime.room.application.dto.input.VotesUpdateInput;
+import com.estime.room.domain.participant.vo.ParticipantName;
 import com.estime.room.domain.slot.vo.DateTimeSlot;
 import com.estime.room.domain.vo.RoomSession;
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -19,7 +20,8 @@ public record ParticipantVotesUpdateRequest(
 ) {
 
     public VotesUpdateInput toInput(final Tsid roomSession) {
-        return new VotesUpdateInput(RoomSession.from(roomSession), participantName,
+        return new VotesUpdateInput(RoomSession.from(roomSession),
+                ParticipantName.from(participantName),
                 dateTimeSlots.stream().map(DateTimeSlot::from).toList());
     }
 }

--- a/estime-api/src/main/java/com/estime/room/presentation/dto/response/DateTimeSlotStatisticResponse.java
+++ b/estime-api/src/main/java/com/estime/room/presentation/dto/response/DateTimeSlotStatisticResponse.java
@@ -1,6 +1,7 @@
 package com.estime.room.presentation.dto.response;
 
 import com.estime.room.application.dto.output.DateTimeSlotStatisticOutput;
+import com.estime.room.domain.participant.vo.ParticipantName;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
@@ -18,10 +19,13 @@ public record DateTimeSlotStatisticResponse(
                 output.participantCount(),
                 output.statistic()
                         .stream()
-                        .map(each -> new DateTimeSlotVotesResponse(
-                                each.dateTimeSlot().getStartAt(),
-                                each.participantNames()
-                        ))
+                        .map(each -> {
+                            final List<ParticipantName> participantNames = each.participantNames();
+                            return new DateTimeSlotVotesResponse(
+                                    each.dateTimeSlot().getStartAt(),
+                                    participantNames.stream().map(ParticipantName::getValue).toList()
+                            );
+                        })
                         .sorted(Comparator.comparing(DateTimeSlotVotesResponse::dateTimeSlot))
                         .toList()
         );

--- a/estime-api/src/main/java/com/estime/room/presentation/dto/response/ParticipantCreateResponse.java
+++ b/estime-api/src/main/java/com/estime/room/presentation/dto/response/ParticipantCreateResponse.java
@@ -8,6 +8,6 @@ public record ParticipantCreateResponse(
         String participantName
 ) {
     public static ParticipantCreateResponse from(final ParticipantCreateOutput output) {
-        return new ParticipantCreateResponse(output.name());
+        return new ParticipantCreateResponse(output.name().getValue());
     }
 }

--- a/estime-api/src/main/java/com/estime/room/presentation/dto/response/ParticipantVotesResponse.java
+++ b/estime-api/src/main/java/com/estime/room/presentation/dto/response/ParticipantVotesResponse.java
@@ -18,7 +18,7 @@ public record ParticipantVotesResponse(
 
     public static ParticipantVotesResponse from(final VotesOutput output) {
         return new ParticipantVotesResponse(
-                output.participantName().getValue(),
+                output.name().getValue(),
                 output.votes().stream()
                         .map(Vote::startAt)
                         .toList()

--- a/estime-api/src/main/java/com/estime/room/presentation/dto/response/ParticipantVotesResponse.java
+++ b/estime-api/src/main/java/com/estime/room/presentation/dto/response/ParticipantVotesResponse.java
@@ -18,7 +18,7 @@ public record ParticipantVotesResponse(
 
     public static ParticipantVotesResponse from(final VotesOutput output) {
         return new ParticipantVotesResponse(
-                output.participantName(),
+                output.participantName().getValue(),
                 output.votes().stream()
                         .map(Vote::startAt)
                         .toList()

--- a/estime-api/src/main/java/com/estime/room/presentation/dto/response/ParticipantVotesUpdateResponse.java
+++ b/estime-api/src/main/java/com/estime/room/presentation/dto/response/ParticipantVotesUpdateResponse.java
@@ -18,7 +18,7 @@ public record ParticipantVotesUpdateResponse(
 
     public static ParticipantVotesUpdateResponse from(final VotesOutput output) {
         return new ParticipantVotesUpdateResponse(
-                output.participantName(),
+                output.participantName().getValue(),
                 output.votes().stream()
                         .map(Vote::startAt)
                         .toList()

--- a/estime-api/src/main/java/com/estime/room/presentation/dto/response/ParticipantVotesUpdateResponse.java
+++ b/estime-api/src/main/java/com/estime/room/presentation/dto/response/ParticipantVotesUpdateResponse.java
@@ -18,7 +18,7 @@ public record ParticipantVotesUpdateResponse(
 
     public static ParticipantVotesUpdateResponse from(final VotesOutput output) {
         return new ParticipantVotesUpdateResponse(
-                output.participantName().getValue(),
+                output.name().getValue(),
                 output.votes().stream()
                         .map(Vote::startAt)
                         .toList()

--- a/estime-api/src/test/java/com/estime/room/application/service/RoomApplicationServiceTest.java
+++ b/estime-api/src/test/java/com/estime/room/application/service/RoomApplicationServiceTest.java
@@ -25,6 +25,7 @@ import com.estime.room.domain.Room;
 import com.estime.room.domain.RoomRepository;
 import com.estime.room.domain.participant.Participant;
 import com.estime.room.domain.participant.ParticipantRepository;
+import com.estime.room.domain.participant.vo.ParticipantName;
 import com.estime.room.domain.participant.vote.Vote;
 import com.estime.room.domain.participant.vote.VoteRepository;
 import com.estime.room.domain.participant.vote.Votes;
@@ -108,8 +109,8 @@ class RoomApplicationServiceTest {
                         DateTimeSlot.from(LocalDateTime.of(LocalDate.now().plusDays(3), LocalTime.of(10, 0)))
                 ));
 
-        participant1 = participantRepository.save(Participant.withoutId(room.getId(), "user1"));
-        participant2 = participantRepository.save(Participant.withoutId(room.getId(), "user2"));
+        participant1 = participantRepository.save(Participant.withoutId(room.getId(), ParticipantName.from("user1")));
+        participant2 = participantRepository.save(Participant.withoutId(room.getId(), ParticipantName.from("user2")));
     }
 
     @DisplayName("방을 생성할 수 있다.")
@@ -184,10 +185,10 @@ class RoomApplicationServiceTest {
             softly.assertThat(result.statistic()).hasSize(1);
             softly.assertThat(result.statistic().getFirst().dateTimeSlot()).isEqualTo(slot1);
             softly.assertThat(result.statistic().getFirst().participantNames())
-                    .containsExactlyInAnyOrder("user1", "user2");
+                    .containsExactlyInAnyOrder(ParticipantName.from("user1"), ParticipantName.from("user2"));
             softly.assertThat(result.statistic().getFirst().dateTimeSlot()).isEqualTo(slot1);
             softly.assertThat(result.statistic().getFirst().participantNames())
-                    .containsExactlyInAnyOrder("user1", "user2");
+                    .containsExactlyInAnyOrder(ParticipantName.from("user1"), ParticipantName.from("user2"));
         });
     }
 
@@ -201,7 +202,7 @@ class RoomApplicationServiceTest {
 
         // when
         final VotesOutput votesOutput = roomApplicationService.getParticipantVotesBySessionAndParticipantName(
-                VotesFindInput.of(room.getSession().getValue(), participant1.getName()));
+                VotesFindInput.of(room.getSession().getValue(), participant1.getName().getValue()));
 
         // then
         assertSoftly(softly -> {
@@ -321,7 +322,8 @@ class RoomApplicationServiceTest {
     @Test
     void createParticipant() {
         // given
-        final ParticipantCreateInput input = new ParticipantCreateInput(room.getSession(), "newUser");
+        final ParticipantCreateInput input = new ParticipantCreateInput(room.getSession(),
+                ParticipantName.from("newUser"));
 
         // when
         final ParticipantCheckOutput output = roomApplicationService.createParticipant(input);
@@ -329,7 +331,9 @@ class RoomApplicationServiceTest {
         // then
         assertSoftly(softly -> {
             softly.assertThat(output.isDuplicateName()).isFalse();
-            softly.assertThat(participantRepository.existsByRoomIdAndName(room.getId(), "newUser")).isTrue();
+            softly.assertThat(
+                            participantRepository.existsByRoomIdAndName(room.getId(), ParticipantName.from("newUser")))
+                    .isTrue();
         });
     }
 

--- a/estime-api/src/test/java/com/estime/room/application/service/RoomApplicationServiceTest.java
+++ b/estime-api/src/test/java/com/estime/room/application/service/RoomApplicationServiceTest.java
@@ -208,7 +208,7 @@ class RoomApplicationServiceTest {
         assertSoftly(softly -> {
             softly.assertThat(votesOutput.votes()).hasSize(1);
             softly.assertThat(votesOutput.votes().getFirst().getId().getDateTimeSlot()).isEqualTo(slot1);
-            softly.assertThat(votesOutput.participantName()).isEqualTo(participant1.getName());
+            softly.assertThat(votesOutput.name()).isEqualTo(participant1.getName());
         });
     }
 
@@ -237,7 +237,7 @@ class RoomApplicationServiceTest {
             softly.assertThat(updatedVotesOutput.votes()).hasSize(2);
             softly.assertThat(updatedVotesOutput.votes()).extracting(vote -> vote.getId().getDateTimeSlot())
                     .containsExactlyInAnyOrder(slotToKeep, slotToAdd);
-            softly.assertThat(updatedVotesOutput.participantName()).isEqualTo(participant1.getName());
+            softly.assertThat(updatedVotesOutput.name()).isEqualTo(participant1.getName());
 
             final Votes persistedVotes = voteRepository.findAllByParticipantId(participant1.getId());
             softly.assertThat(persistedVotes.getElements()).hasSize(2);
@@ -272,7 +272,7 @@ class RoomApplicationServiceTest {
             softly.assertThat(updatedVotesOutput.votes()).hasSize(2);
             softly.assertThat(updatedVotesOutput.votes()).extracting(vote -> vote.getId().getDateTimeSlot())
                     .containsExactlyInAnyOrder(newSlot1, newSlot2);
-            softly.assertThat(updatedVotesOutput.participantName()).isEqualTo(participant1.getName());
+            softly.assertThat(updatedVotesOutput.name()).isEqualTo(participant1.getName());
         });
     }
 
@@ -292,7 +292,7 @@ class RoomApplicationServiceTest {
         // then
         assertSoftly(softly -> {
             softly.assertThat(updatedVotesOutput.votes()).isEmpty();
-            softly.assertThat(updatedVotesOutput.participantName()).isEqualTo(participant1.getName());
+            softly.assertThat(updatedVotesOutput.name()).isEqualTo(participant1.getName());
             softly.assertThat(voteRepository.findAllByParticipantId(participant1.getId()).isEmpty()).isTrue();
         });
     }
@@ -314,7 +314,7 @@ class RoomApplicationServiceTest {
         assertSoftly(softly -> {
             softly.assertThat(updatedVotesOutput.votes()).hasSize(1);
             softly.assertThat(updatedVotesOutput.votes().getFirst().getId().getDateTimeSlot()).isEqualTo(slot1);
-            softly.assertThat(updatedVotesOutput.participantName()).isEqualTo(participant1.getName());
+            softly.assertThat(updatedVotesOutput.name()).isEqualTo(participant1.getName());
         });
     }
 

--- a/estime-api/src/test/java/com/estime/room/domain/RoomTest.java
+++ b/estime-api/src/test/java/com/estime/room/domain/RoomTest.java
@@ -98,7 +98,7 @@ class RoomTest {
                 List.of(timeSlot),
                 futureDeadline
         )).isInstanceOf(InvalidLengthException.class)
-          .hasMessageContaining(DomainTerm.ROOM.name());
+                .hasMessageContaining(DomainTerm.ROOM.name());
     }
 
     @DisplayName("제목이 최대 길이(20)와 같으면 예외가 발생하지 않는다")
@@ -129,6 +129,6 @@ class RoomTest {
                 List.of(timeSlot),
                 futureDeadline
         )).isInstanceOf(InvalidLengthException.class)
-          .hasMessageContaining(DomainTerm.ROOM.name());
+                .hasMessageContaining(DomainTerm.ROOM.name());
     }
 }

--- a/estime-api/src/test/java/com/estime/room/domain/participant/ParticipantTest.java
+++ b/estime-api/src/test/java/com/estime/room/domain/participant/ParticipantTest.java
@@ -5,42 +5,37 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.estime.common.DomainTerm;
 import com.estime.common.exception.domain.InvalidLengthException;
+import com.estime.room.domain.participant.vo.ParticipantName;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class ParticipantTest {
 
-    @DisplayName("이름이 최대 길이(12)를 초과하면 InvalidLengthException이 발생한다")
-    @Test
-    void validateName_exceedMaxLength_throwsException() {
-        // given
-        String invalidName = "이름이너무길어서예외가발생합니다";
-
-        // when & then
-        assertThatThrownBy(() -> Participant.withoutId(1L, invalidName))
-                .isInstanceOf(InvalidLengthException.class)
-                .hasMessageContaining(DomainTerm.PARTICIPANT.name());
-    }
-
     @DisplayName("이름이 최대 길이(12)와 같으면 예외가 발생하지 않는다")
     @Test
     void validateName_exactMaxLength_success() {
         // given
-        String exactLengthName = "열두글자이름입니다열두글";
+        ParticipantName exactLengthName = ParticipantName.from("열두글자이름입니다열두글");
 
         // when & then
         assertThatCode(() -> Participant.withoutId(1L, exactLengthName))
                 .doesNotThrowAnyException();
     }
 
+    @DisplayName("이름이 최대 길이(12)를 초과하면 InvalidLengthException이 발생한다")
+    @Test
+    void validateName_exceedMaxLength_throwsException() {
+        // when & then
+        assertThatThrownBy(() -> ParticipantName.from("이름이너무길어서예외가발생합니다"))
+                .isInstanceOf(InvalidLengthException.class)
+                .hasMessageContaining(DomainTerm.PARTICIPANT.name());
+    }
+
     @DisplayName("이름이 빈 문자열이면 InvalidLengthException이 발생한다")
     @Test
     void validateName_blank_throwsException() {
-        // given
-        String blankName = "   ";
-
         // when & then
-        assertThatThrownBy(() -> Participant.withoutId(1L, blankName))
+        assertThatThrownBy(() -> ParticipantName.from("   "))
                 .isInstanceOf(InvalidLengthException.class)
                 .hasMessageContaining(DomainTerm.PARTICIPANT.name());
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #476 

## 📝 작업 내용

- ParticipantName 값 객체 포장 및 검증로직
- ParticipantNameConverter 구현
- Controller / Request, Response Dto : String 타입 고정
- Service / Repository / Input, Ouput Dto : ParticipantName 타입 고정

## 💬 리뷰 요구사항

String 타입으로 ParticipantName을 다루었더니, 

`제프리` 로 가입된 Room에서
` 제프리` (앞에 공백 추가) 로 Participant 등록을 할 시 `NotFoundException` 이 발생하였습니다.

String타입으로 데이터를 전달받다보니, `trim()` 이 적용되는 문자열을 추적하기 어려운 관계로 값 객체로 포장하였습니다.
