### PR TITLE
투표 리마인드(독려) 및 데드라인(마감) 디스코드 알림을 위한 스케줄러 추가

### DIFF
--- a/estime-api/src/main/java/com/estime/common/DomainTerm.java
+++ b/estime-api/src/main/java/com/estime/common/DomainTerm.java
@@ -14,6 +14,7 @@ public enum DomainTerm {
     VOTE("투표"),
     VOTES("투표들"),
     DEADLINE("마감일"),
+    PLATFORM("플랫폼")
     ;
 
     private final String label;

--- a/estime-api/src/main/java/com/estime/common/exception/GlobalExceptionHandler.java
+++ b/estime-api/src/main/java/com/estime/common/exception/GlobalExceptionHandler.java
@@ -13,19 +13,19 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(DomainException.class)
-    public CustomApiResponse<Void> handleDomainException(DomainException e) {
+    public CustomApiResponse<Void> handleDomainException(final DomainException e) {
         log.warn(e.getLogMessage());
         return CustomApiResponse.badRequest(e.getUserMessage());
     }
 
     @ExceptionHandler(ApplicationException.class)
-    public CustomApiResponse<Void> handleApplicationException(ApplicationException e) {
+    public CustomApiResponse<Void> handleApplicationException(final ApplicationException e) {
         log.warn(e.getLogMessage());
         return CustomApiResponse.badRequest(e.getUserMessage());
     }
 
     @ExceptionHandler(Exception.class)
-    public CustomApiResponse<Void> handleException(Exception e) {
+    public CustomApiResponse<Void> handleException(final Exception e) {
         MDC.put("message", e.getMessage());
         log.error(e.getMessage());
         return CustomApiResponse.internalServerError("서버에서 예기치 못한 에러가 발생했습니다.");

--- a/estime-api/src/main/java/com/estime/common/presentation/RootController.java
+++ b/estime-api/src/main/java/com/estime/common/presentation/RootController.java
@@ -12,7 +12,7 @@ public class RootController {
 
     @GetMapping("/")
     public Map<String, String> healthCheck() {
-        Map<String, String> response = new HashMap<>();
+        final Map<String, String> response = new HashMap<>();
         response.put("status", "ok");
         response.put("message", "Estime API Server is running!");
         return response;

--- a/estime-api/src/main/java/com/estime/common/sse/application/SseSender.java
+++ b/estime-api/src/main/java/com/estime/common/sse/application/SseSender.java
@@ -27,7 +27,8 @@ public class SseSender {
                                 .data(SseResponse.from("ok"))
                 );
             } catch (final IOException e) {
-                throw new RuntimeException("Failed to send SSE message for roomSession " + roomSession + ":" + e.getMessage(), e);
+                throw new RuntimeException(
+                        "Failed to send SSE message for roomSession " + roomSession + ":" + e.getMessage(), e);
             }
         }
     }

--- a/estime-api/src/main/java/com/estime/notification/application/NotificationService.java
+++ b/estime-api/src/main/java/com/estime/notification/application/NotificationService.java
@@ -1,11 +1,12 @@
 package com.estime.notification.application;
 
+import com.estime.common.DomainTerm;
+import com.estime.common.exception.application.NotFoundException;
 import com.estime.room.domain.Room;
 import com.estime.room.domain.RoomRepository;
 import com.estime.room.domain.platform.Platform;
 import com.estime.room.domain.platform.PlatformRepository;
 import com.estime.room.infrastructure.platform.discord.DiscordMessageSender;
-import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -25,14 +26,11 @@ public class NotificationService {
         log.info("Preparing REMINDER notification for room: {}", roomId);
         try {
             final Room room = roomRepository.findById(roomId)
-                    .orElseThrow(() -> new NoSuchElementException("Room not found with id: " + roomId));
+                    .orElseThrow(() -> new NotFoundException(DomainTerm.ROOM, roomId));
             final Platform platform = platformRepository.findByRoomId(roomId)
-                    .orElseThrow(() -> new NoSuchElementException("Platform not found for room id: " + roomId));
+                    .orElseThrow(() -> new NotFoundException(DomainTerm.PLATFORM, roomId));
 
-            final String channelId = platform.getChannelId();
-            final String roomTitle = room.getTitle();
-
-            discordMessageSender.sendReminderMessage(channelId, roomTitle);
+            discordMessageSender.sendReminderMessage(platform.getChannelId(), room.getTitle());
             log.info("Successfully sent REMINDER for room {}", roomId);
 
         } catch (final Exception e) {
@@ -45,14 +43,11 @@ public class NotificationService {
         log.info("Preparing DEADLINE ALERT for room: {}", roomId);
         try {
             final Room room = roomRepository.findById(roomId)
-                    .orElseThrow(() -> new NoSuchElementException("Room not found with id: " + roomId));
+                    .orElseThrow(() -> new NotFoundException(DomainTerm.ROOM, roomId));
             final Platform platform = platformRepository.findByRoomId(roomId)
-                    .orElseThrow(() -> new NoSuchElementException("Platform not found for room id: " + roomId));
+                    .orElseThrow(() -> new NotFoundException(DomainTerm.PLATFORM, roomId));
 
-            final String channelId = platform.getChannelId();
-            final String roomTitle = room.getTitle();
-
-            discordMessageSender.sendDeadlineAlertMessage(channelId, roomTitle);
+            discordMessageSender.sendDeadlineAlertMessage(platform.getChannelId(), room.getTitle());
             log.info("Successfully sent DEADLINE ALERT for room {}", roomId);
 
         } catch (final Exception e) {

--- a/estime-api/src/main/java/com/estime/notification/application/NotificationService.java
+++ b/estime-api/src/main/java/com/estime/notification/application/NotificationService.java
@@ -1,0 +1,62 @@
+package com.estime.notification.application;
+
+import com.estime.room.domain.Room;
+import com.estime.room.domain.RoomRepository;
+import com.estime.room.domain.platform.Platform;
+import com.estime.room.domain.platform.PlatformRepository;
+import com.estime.room.infrastructure.platform.discord.DiscordMessageSender;
+import java.util.NoSuchElementException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final RoomRepository roomRepository;
+    private final PlatformRepository platformRepository;
+    private final DiscordMessageSender discordMessageSender;
+
+    @Transactional(readOnly = true)
+    public void sendReminderNotification(final Long roomId) {
+        log.info("Preparing REMINDER notification for room: {}", roomId);
+        try {
+            final Room room = roomRepository.findById(roomId)
+                    .orElseThrow(() -> new NoSuchElementException("Room not found with id: " + roomId));
+            final Platform platform = platformRepository.findByRoomId(roomId)
+                    .orElseThrow(() -> new NoSuchElementException("Platform not found for room id: " + roomId));
+
+            final String channelId = platform.getChannelId();
+            final String roomTitle = room.getTitle();
+
+            discordMessageSender.sendReminderMessage(channelId, roomTitle);
+            log.info("Successfully sent REMINDER for room {}", roomId);
+
+        } catch (final Exception e) {
+            log.error("Failed to send reminder for room: {}", roomId, e);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public void sendDeadlineAlert(final Long roomId) {
+        log.info("Preparing DEADLINE ALERT for room: {}", roomId);
+        try {
+            final Room room = roomRepository.findById(roomId)
+                    .orElseThrow(() -> new NoSuchElementException("Room not found with id: " + roomId));
+            final Platform platform = platformRepository.findByRoomId(roomId)
+                    .orElseThrow(() -> new NoSuchElementException("Platform not found for room id: " + roomId));
+
+            final String channelId = platform.getChannelId();
+            final String roomTitle = room.getTitle();
+
+            discordMessageSender.sendDeadlineAlertMessage(channelId, roomTitle);
+            log.info("Successfully sent DEADLINE ALERT for room {}", roomId);
+
+        } catch (final Exception e) {
+            log.error("Failed to send deadline alert for room: {}", roomId, e);
+        }
+    }
+}

--- a/estime-api/src/main/java/com/estime/room/application/RoomDeadlineScheduler.java
+++ b/estime-api/src/main/java/com/estime/room/application/RoomDeadlineScheduler.java
@@ -98,11 +98,6 @@ public class RoomDeadlineScheduler {
 
         for (final Room room : rooms) {
             final LocalDateTime deadline = room.getDeadline();
-            if (deadline == null) {
-                log.warn("Room {} has null deadline, skipping", room.getId());
-                continue;
-            }
-
             if (!deadline.isAfter(referenceTime)) {
                 continue;
             }

--- a/estime-api/src/main/java/com/estime/room/application/RoomDeadlineScheduler.java
+++ b/estime-api/src/main/java/com/estime/room/application/RoomDeadlineScheduler.java
@@ -1,0 +1,119 @@
+package com.estime.room.application;
+
+import com.estime.notification.application.NotificationService;
+import com.estime.room.application.vo.NotificationTask;
+import com.estime.room.application.vo.NotificationTaskType;
+import com.estime.room.domain.Room;
+import com.estime.room.domain.RoomRepository;
+import jakarta.annotation.PostConstruct;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RoomDeadlineScheduler {
+
+    private static final int REMINDER_HOURS_BEFORE_DEADLINE = 1;
+    private final RoomRepository roomRepository;
+    private final NotificationService notificationService;
+    private final Queue<NotificationTask> taskQueue = new PriorityBlockingQueue<>();
+    private final AtomicReference<Long> lastCheckedRoomId = new AtomicReference<>();
+
+    @PostConstruct
+    public void initialize() {
+        log.info("Initializing scheduler: Populating task queue from existing rooms...");
+        final LocalDateTime now = LocalDateTime.now();
+
+        final List<Room> existingRooms = roomRepository.findAllByDeadlineAfter(now);
+        populateQueueWithTasks(existingRooms, now);
+
+        existingRooms.stream()
+                .map(Room::getId)
+                .max(Comparator.naturalOrder())
+                .ifPresent(lastCheckedRoomId::set);
+
+        log.info("Scheduler initialized. Last checked ID: {}. Initial queue size: {}",
+                lastCheckedRoomId.get(), taskQueue.size());
+    }
+
+    @Scheduled(cron = "0 */5 * * * *")
+    public void pollNewRooms() {
+        final Long currentLastId = lastCheckedRoomId.get();
+        final List<Room> newRooms;
+        final LocalDateTime now = LocalDateTime.now();
+
+        if (currentLastId == null) {
+            log.warn("No last checked ID found, re-initializing from all rooms.");
+            newRooms = roomRepository.findAllByDeadlineAfter(now);
+        } else {
+            log.info("Polling for new rooms with ID greater than {}.", currentLastId);
+            newRooms = roomRepository.findAllByIdGreaterThanOrderByIdAsc(currentLastId);
+        }
+
+        if (newRooms.isEmpty()) {
+            return;
+        }
+
+        log.info("Found {} new rooms to schedule.", newRooms.size());
+        populateQueueWithTasks(newRooms, now);
+
+        newRooms.stream()
+                .map(Room::getId)
+                .max(Comparator.naturalOrder())
+                .ifPresent(lastCheckedRoomId::set);
+
+        log.info("Polling complete. Last checked ID is now {}. Queue size is {}.",
+                lastCheckedRoomId.get(), taskQueue.size());
+    }
+
+    @Scheduled(cron = "0 */30 * * * *")
+    public void processTaskQueue() {
+        final LocalDateTime now = LocalDateTime.now();
+        log.debug("Processing task queue at {}. Current queue size: {}", now, taskQueue.size());
+
+        while (!taskQueue.isEmpty() && !taskQueue.peek().executionTime().isAfter(now)) {
+            final NotificationTask task = taskQueue.poll();
+            log.info("Processing task: {} for roomId: {}", task.taskType(), task.roomId());
+
+            switch (task.taskType()) {
+                case NotificationTaskType.REMIND -> notificationService.sendReminderNotification(task.roomId());
+                case NotificationTaskType.DEADLINE -> notificationService.sendDeadlineAlert(task.roomId());
+            }
+        }
+    }
+
+    private void populateQueueWithTasks(final List<Room> rooms, final LocalDateTime referenceTime) {
+        if (rooms == null || rooms.isEmpty()) {
+            return;
+        }
+
+        for (final Room room : rooms) {
+            final LocalDateTime deadline = room.getDeadline();
+            if (deadline == null) {
+                log.warn("Room {} has null deadline, skipping", room.getId());
+                continue;
+            }
+
+            if (!deadline.isAfter(referenceTime)) {
+                continue;
+            }
+
+            taskQueue.add(new NotificationTask(room.getId(), deadline, NotificationTaskType.DEADLINE));
+
+            final LocalDateTime reminderTime = deadline.minusHours(REMINDER_HOURS_BEFORE_DEADLINE);
+            if (reminderTime.isAfter(referenceTime)) {
+                taskQueue.add(
+                        new NotificationTask(room.getId(), reminderTime, NotificationTaskType.REMIND));
+            }
+        }
+    }
+}

--- a/estime-api/src/main/java/com/estime/room/application/RoomDeadlineScheduler.java
+++ b/estime-api/src/main/java/com/estime/room/application/RoomDeadlineScheduler.java
@@ -75,7 +75,7 @@ public class RoomDeadlineScheduler {
                 lastCheckedRoomId.get(), taskQueue.size());
     }
 
-    @Scheduled(cron = "0 */30 * * * *")
+    @Scheduled(cron = "0 */5 * * * *")
     public void processTaskQueue() {
         final LocalDateTime now = LocalDateTime.now();
         log.debug("Processing task queue at {}. Current queue size: {}", now, taskQueue.size());

--- a/estime-api/src/main/java/com/estime/room/application/dto/input/ConnectedRoomCreateInput.java
+++ b/estime-api/src/main/java/com/estime/room/application/dto/input/ConnectedRoomCreateInput.java
@@ -3,15 +3,15 @@ package com.estime.room.application.dto.input;
 import com.estime.room.domain.platform.PlatformNotification;
 import com.estime.room.domain.platform.PlatformType;
 import com.estime.room.domain.slot.vo.DateSlot;
-import com.estime.room.domain.slot.vo.DateTimeSlot;
 import com.estime.room.domain.slot.vo.TimeSlot;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record ConnectedRoomCreateInput(
         String title,
         List<DateSlot> availableDates,
         List<TimeSlot> availableTimes,
-        DateTimeSlot deadline,
+        LocalDateTime deadline,
         PlatformType type,
         String channelId,
         PlatformNotification notification

--- a/estime-api/src/main/java/com/estime/room/application/dto/input/RoomCreateInput.java
+++ b/estime-api/src/main/java/com/estime/room/application/dto/input/RoomCreateInput.java
@@ -2,15 +2,15 @@ package com.estime.room.application.dto.input;
 
 import com.estime.room.domain.Room;
 import com.estime.room.domain.slot.vo.DateSlot;
-import com.estime.room.domain.slot.vo.DateTimeSlot;
 import com.estime.room.domain.slot.vo.TimeSlot;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record RoomCreateInput(
         String title,
         List<DateSlot> availableDateSlots,
         List<TimeSlot> availableTimeSlots,
-        DateTimeSlot deadline
+        LocalDateTime deadline
 ) {
 
     public Room toEntity() {

--- a/estime-api/src/main/java/com/estime/room/application/dto/input/RoomSessionInput.java
+++ b/estime-api/src/main/java/com/estime/room/application/dto/input/RoomSessionInput.java
@@ -7,7 +7,7 @@ public record RoomSessionInput(
         RoomSession session
 ) {
 
-    public static RoomSessionInput from(Tsid roomSession) {
+    public static RoomSessionInput from(final Tsid roomSession) {
         return new RoomSessionInput(RoomSession.from(roomSession));
     }
 }

--- a/estime-api/src/main/java/com/estime/room/application/dto/input/VotesFindInput.java
+++ b/estime-api/src/main/java/com/estime/room/application/dto/input/VotesFindInput.java
@@ -9,7 +9,7 @@ public record VotesFindInput(
         ParticipantName name
 ) {
 
-    public static VotesFindInput of(Tsid roomSession, String participantName) {
+    public static VotesFindInput of(final Tsid roomSession, final String participantName) {
         return new VotesFindInput(
                 RoomSession.from(roomSession),
                 ParticipantName.from(participantName)

--- a/estime-api/src/main/java/com/estime/room/application/dto/output/RoomOutput.java
+++ b/estime-api/src/main/java/com/estime/room/application/dto/output/RoomOutput.java
@@ -2,16 +2,16 @@ package com.estime.room.application.dto.output;
 
 import com.estime.room.domain.Room;
 import com.estime.room.domain.slot.vo.DateSlot;
-import com.estime.room.domain.slot.vo.DateTimeSlot;
 import com.estime.room.domain.slot.vo.TimeSlot;
 import com.estime.room.domain.vo.RoomSession;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record RoomOutput(
         String title,
         List<DateSlot> availableDateSlots,
         List<TimeSlot> availableTimeSlots,
-        DateTimeSlot deadline,
+        LocalDateTime deadline,
         RoomSession session
 ) {
 

--- a/estime-api/src/main/java/com/estime/room/application/vo/NotificationTask.java
+++ b/estime-api/src/main/java/com/estime/room/application/vo/NotificationTask.java
@@ -1,0 +1,15 @@
+package com.estime.room.application.vo;
+
+import java.time.LocalDateTime;
+
+public record NotificationTask(
+        Long roomId,
+        LocalDateTime executionTime,
+        NotificationTaskType taskType
+) implements Comparable<NotificationTask> {
+
+    @Override
+    public int compareTo(final NotificationTask other) {
+        return this.executionTime.compareTo(other.executionTime);
+    }
+}

--- a/estime-api/src/main/java/com/estime/room/application/vo/NotificationTaskType.java
+++ b/estime-api/src/main/java/com/estime/room/application/vo/NotificationTaskType.java
@@ -1,0 +1,6 @@
+package com.estime.room.application.vo;
+
+public enum NotificationTaskType {
+    REMIND,
+    DEADLINE
+}

--- a/estime-api/src/main/java/com/estime/room/domain/Room.java
+++ b/estime-api/src/main/java/com/estime/room/domain/Room.java
@@ -12,7 +12,6 @@ import com.estime.room.domain.slot.vo.DateTimeSlot;
 import com.estime.room.domain.slot.vo.TimeSlot;
 import com.estime.room.domain.vo.RoomSession;
 import com.estime.room.infrastructure.converter.DateSlotConverter;
-import com.estime.room.infrastructure.converter.DateTimeSlotConverter;
 import com.estime.room.infrastructure.converter.RoomSessionConverter;
 import com.estime.room.infrastructure.converter.TimeSlotConverter;
 import jakarta.persistence.CollectionTable;
@@ -68,14 +67,13 @@ public class Room extends BaseEntity {
     private Set<TimeSlot> availableTimeSlots;
 
     @Column(name = "deadline", nullable = false)
-    @Convert(converter = DateTimeSlotConverter.class)
-    private DateTimeSlot deadline;
+    private LocalDateTime deadline;
 
     public static Room withoutId(
             final String title,
             final List<DateSlot> availableDateSlots,
             final List<TimeSlot> availableTimeSlots,
-            final DateTimeSlot deadline
+            final LocalDateTime deadline
     ) {
         validateNull(title, availableDateSlots, availableTimeSlots, deadline);
         final String trimmedTitle = title.trim();
@@ -94,7 +92,7 @@ public class Room extends BaseEntity {
             final String title,
             final List<DateSlot> availableDateSlots,
             final List<TimeSlot> availableTimeSlots,
-            final DateTimeSlot deadline
+            final LocalDateTime deadline
     ) {
         Validator.builder()
                 .add(Fields.title, title)
@@ -110,7 +108,7 @@ public class Room extends BaseEntity {
         }
     }
 
-    private static void validateDeadline(final DateTimeSlot deadline) {
+    private static void validateDeadline(final LocalDateTime deadline) {
         if (deadline.isBefore(LocalDateTime.now())) {
             throw new PastNotAllowedException(DomainTerm.DEADLINE, deadline);
         }

--- a/estime-api/src/main/java/com/estime/room/domain/RoomRepository.java
+++ b/estime-api/src/main/java/com/estime/room/domain/RoomRepository.java
@@ -1,13 +1,22 @@
 package com.estime.room.domain;
 
 import com.estime.room.domain.vo.RoomSession;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface RoomRepository {
 
     Room save(Room room);
 
+    Optional<Room> findById(Long id);
+
+    List<Room> findAllByIdGreaterThanOrderByIdAsc(Long id);
+
+    List<Room> findAllByDeadlineAfter(LocalDateTime criterion);
+
     Optional<Room> findBySession(RoomSession session);
 
     Optional<Long> findIdBySession(RoomSession session);
 }
+

--- a/estime-api/src/main/java/com/estime/room/domain/platform/PlatformCommand.java
+++ b/estime-api/src/main/java/com/estime/room/domain/platform/PlatformCommand.java
@@ -1,6 +1,5 @@
 package com.estime.room.domain.platform;
 
-import java.util.stream.Stream;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -14,13 +13,4 @@ public enum PlatformCommand {
 
     private final String value;
     private final String description;
-
-    public static boolean exists(final String command) {
-        return Stream.of(values())
-                .anyMatch(cmd -> cmd.getValueWithSlash().equals(command));
-    }
-
-    public String getValueWithSlash() {
-        return "/" + value;
-    }
 }

--- a/estime-api/src/main/java/com/estime/room/domain/platform/PlatformMessage.java
+++ b/estime-api/src/main/java/com/estime/room/domain/platform/PlatformMessage.java
@@ -1,11 +1,15 @@
 package com.estime.room.domain.platform;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
+@Getter
 public enum PlatformMessage {
 
-    HELP("아인슈타임을 호출했습니다! 👋", "`/도움말` 로 사용법을 확인해 보세요!"),
+    JOIN("아인슈타임을 호출했습니다!", "`/도움말` 로 사용법을 확인해 보세요!"),
+    HELP("아인슈타임 사용법!", "`/시작하기` 로 디스코드와 연동된 일정 조율을 시작할 수 있어요!"),
+
     ROOM_CREATE("아인슈타임이 나타났어요!", "일정 조율 시작하기"),
     ROOM_CREATED("아인슈타임이 기다려요!", "일정 조율 참여하기"),
     ROOM_REMIND("아인슈타임이 초조해요!", "일정 조율 참여하기"),
@@ -16,11 +20,11 @@ public enum PlatformMessage {
     private final String title;
     private final String description;
 
-    public String getTitle() {
+    public String getTitleWithEmoji() {
         return "💡 " + title;
     }
 
-    public String getDescription() {
+    public String getDescriptionWithEmoji() {
         return "🔗 " + description;
     }
 }

--- a/estime-api/src/main/java/com/estime/room/infrastructure/RoomJpaRepository.java
+++ b/estime-api/src/main/java/com/estime/room/infrastructure/RoomJpaRepository.java
@@ -2,10 +2,20 @@ package com.estime.room.infrastructure;
 
 import com.estime.room.domain.Room;
 import com.estime.room.domain.vo.RoomSession;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RoomJpaRepository extends JpaRepository<Room, Long> {
 
     Optional<Room> findBySessionAndActiveTrue(RoomSession session);
+
+    List<Room> findAllByIdGreaterThanOrderByIdAsc(Long id);
+
+    @Query("SELECT r FROM Room r WHERE r.deadline > :deadline")
+    List<Room> findAllByDeadlineAfter(@Param("deadline") LocalDateTime deadline);
+
 }

--- a/estime-api/src/main/java/com/estime/room/infrastructure/RoomJpaRepository.java
+++ b/estime-api/src/main/java/com/estime/room/infrastructure/RoomJpaRepository.java
@@ -6,16 +6,14 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface RoomJpaRepository extends JpaRepository<Room, Long> {
 
     Optional<Room> findBySessionAndActiveTrue(RoomSession session);
 
-    List<Room> findAllByIdGreaterThanOrderByIdAsc(Long id);
+    Optional<Room> findByIdAndActiveTrue(Long id);
 
-    @Query("SELECT r FROM Room r WHERE r.deadline > :deadline")
-    List<Room> findAllByDeadlineAfter(@Param("deadline") LocalDateTime deadline);
+    List<Room> findAllByIdGreaterThanAndActiveTrueOrderByIdAsc(Long id);
 
+    List<Room> findAllByDeadlineAfterAndActiveTrue(LocalDateTime deadline);
 }

--- a/estime-api/src/main/java/com/estime/room/infrastructure/RoomRepositoryImpl.java
+++ b/estime-api/src/main/java/com/estime/room/infrastructure/RoomRepositoryImpl.java
@@ -3,6 +3,8 @@ package com.estime.room.infrastructure;
 import com.estime.room.domain.Room;
 import com.estime.room.domain.RoomRepository;
 import com.estime.room.domain.vo.RoomSession;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -16,6 +18,21 @@ public class RoomRepositoryImpl implements RoomRepository {
     @Override
     public Room save(final Room room) {
         return roomJpaRepository.save(room);
+    }
+
+    @Override
+    public Optional<Room> findById(final Long id) {
+        return roomJpaRepository.findById(id);
+    }
+
+    @Override
+    public List<Room> findAllByIdGreaterThanOrderByIdAsc(final Long id) {
+        return roomJpaRepository.findAllByIdGreaterThanOrderByIdAsc(id);
+    }
+
+    @Override
+    public List<Room> findAllByDeadlineAfter(final LocalDateTime criterion) {
+        return roomJpaRepository.findAllByDeadlineAfter(criterion);
     }
 
     @Override

--- a/estime-api/src/main/java/com/estime/room/infrastructure/RoomRepositoryImpl.java
+++ b/estime-api/src/main/java/com/estime/room/infrastructure/RoomRepositoryImpl.java
@@ -21,21 +21,6 @@ public class RoomRepositoryImpl implements RoomRepository {
     }
 
     @Override
-    public Optional<Room> findById(final Long id) {
-        return roomJpaRepository.findById(id);
-    }
-
-    @Override
-    public List<Room> findAllByIdGreaterThanOrderByIdAsc(final Long id) {
-        return roomJpaRepository.findAllByIdGreaterThanOrderByIdAsc(id);
-    }
-
-    @Override
-    public List<Room> findAllByDeadlineAfter(final LocalDateTime criterion) {
-        return roomJpaRepository.findAllByDeadlineAfter(criterion);
-    }
-
-    @Override
     public Optional<Room> findBySession(final RoomSession session) {
         return roomJpaRepository.findBySessionAndActiveTrue(session);
     }
@@ -43,5 +28,20 @@ public class RoomRepositoryImpl implements RoomRepository {
     @Override
     public Optional<Long> findIdBySession(final RoomSession session) {
         return findBySession(session).map(Room::getId);
+    }
+
+    @Override
+    public Optional<Room> findById(final Long id) {
+        return roomJpaRepository.findByIdAndActiveTrue(id);
+    }
+
+    @Override
+    public List<Room> findAllByIdGreaterThanOrderByIdAsc(final Long id) {
+        return roomJpaRepository.findAllByIdGreaterThanAndActiveTrueOrderByIdAsc(id);
+    }
+
+    @Override
+    public List<Room> findAllByDeadlineAfter(final LocalDateTime criterion) {
+        return roomJpaRepository.findAllByDeadlineAfterAndActiveTrue(criterion);
     }
 }

--- a/estime-api/src/main/java/com/estime/room/infrastructure/converter/TsidConverter.java
+++ b/estime-api/src/main/java/com/estime/room/infrastructure/converter/TsidConverter.java
@@ -12,7 +12,7 @@ public class TsidConverter implements Converter<String, Tsid> {
     public Tsid convert(final String source) {
         try {
             return Tsid.from(source);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             throw new InternalLogOnlyException("Invalid TSID format", source);
         }
     }

--- a/estime-api/src/main/java/com/estime/room/infrastructure/platform/discord/DiscordGuildJoinMessageRegistrar.java
+++ b/estime-api/src/main/java/com/estime/room/infrastructure/platform/discord/DiscordGuildJoinMessageRegistrar.java
@@ -22,8 +22,8 @@ public class DiscordGuildJoinMessageRegistrar extends ListenerAdapter {
         channel.sendMessageEmbeds(
                 new EmbedBuilder()
                         .setColor(PlatformMessageStyle.DEFAULT.getColor())
-                        .setTitle(PlatformMessage.HELP.getTitle())
-                        .setDescription(PlatformMessage.HELP.getDescription())
+                        .setTitle(PlatformMessage.JOIN.getTitleWithEmoji())
+                        .setDescription(PlatformMessage.JOIN.getDescriptionWithEmoji())
                         .build()
         ).queue();
     }

--- a/estime-api/src/main/java/com/estime/room/infrastructure/platform/discord/DiscordMessageBuilder.java
+++ b/estime-api/src/main/java/com/estime/room/infrastructure/platform/discord/DiscordMessageBuilder.java
@@ -63,4 +63,28 @@ public class DiscordMessageBuilder {
                 .setActionRow(Button.link(shortcut, platformMessage.getDescriptionWithEmoji()))
                 .build();
     }
+
+    public MessageCreateData buildReminderMessage(final String roomTitle) {
+        final MessageEmbed embed = new EmbedBuilder()
+                .setTitle("⏰ 리마인더")
+                .setDescription(String.format("> '%s' 방의 마감이 1시간 남았습니다! 서둘러 참여해주세요!", roomTitle))
+                .setColor(PlatformMessageStyle.DEFAULT.getColor())
+                .build();
+
+        return new MessageCreateBuilder()
+                .setEmbeds(embed)
+                .build();
+    }
+
+    public MessageCreateData buildDeadlineAlertMessage(final String roomTitle) {
+        final MessageEmbed embed = new EmbedBuilder()
+                .setTitle("⌛️ 마감 알림")
+                .setDescription(String.format("> '%s' 방이 마감되었습니다. 참여해주셔서 감사합니다!", roomTitle))
+                .setColor(PlatformMessageStyle.DEFAULT.getColor())
+                .build();
+
+        return new MessageCreateBuilder()
+                .setEmbeds(embed)
+                .build();
+    }
 }

--- a/estime-api/src/main/java/com/estime/room/infrastructure/platform/discord/DiscordMessageBuilder.java
+++ b/estime-api/src/main/java/com/estime/room/infrastructure/platform/discord/DiscordMessageBuilder.java
@@ -2,7 +2,7 @@ package com.estime.room.infrastructure.platform.discord;
 
 import com.estime.room.domain.platform.PlatformMessage;
 import com.estime.room.domain.platform.PlatformMessageStyle;
-import com.estime.room.domain.slot.vo.DateTimeSlot;
+import java.time.LocalDateTime;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
@@ -45,9 +45,9 @@ public class DiscordMessageBuilder {
     public MessageCreateData buildConnectedRoomCreatedMessage(
             final String shortcut,
             final String title,
-            final DateTimeSlot deadline) {
+            final LocalDateTime deadline) {
         final PlatformMessage platformMessage = PlatformMessage.ROOM_CREATED;
-        final String formattedDeadline = deadline.getStartAt()
+        final String formattedDeadline = deadline
                 .format(PlatformMessageStyle.DEFAULT.getDateTimeFormatter());
         final MessageEmbed embed = new EmbedBuilder()
                 .setTitle(platformMessage.getTitleWithEmoji())

--- a/estime-api/src/main/java/com/estime/room/infrastructure/platform/discord/DiscordMessageBuilder.java
+++ b/estime-api/src/main/java/com/estime/room/infrastructure/platform/discord/DiscordMessageBuilder.java
@@ -13,16 +13,32 @@ import org.springframework.stereotype.Component;
 @Component
 public class DiscordMessageBuilder {
 
-    public MessageCreateData buildConnectedRoomCreateMessage(final String shortcut) {
+    public MessageCreateData buildHelpMessage() {
+        final PlatformMessage platformMessage = PlatformMessage.HELP;
+
+        final MessageEmbed embed = new EmbedBuilder()
+                .setTitle(platformMessage.getTitleWithEmoji())
+                .setDescription(platformMessage.getDescription())
+                .setColor(PlatformMessageStyle.DEFAULT.getColor())
+                .build();
+
+        final String creditsShortcut = "https://estime.today/credits";
+        return new MessageCreateBuilder()
+                .setEmbeds(embed)
+                .setActionRow(Button.link(creditsShortcut, "아인슈타임을 만든 사람들"))
+                .build();
+    }
+
+    public MessageCreateData buildConnectedRoomCreateMessage(final String roomCreateShortcut) {
         final PlatformMessage platformMessage = PlatformMessage.ROOM_CREATE;
         final MessageEmbed embed = new EmbedBuilder()
-                .setTitle(platformMessage.getTitle())
+                .setTitle(platformMessage.getTitleWithEmoji())
                 .setColor(PlatformMessageStyle.DEFAULT.getColor())
                 .build();
 
         return new MessageCreateBuilder()
                 .setEmbeds(embed)
-                .setActionRow(Button.link(shortcut, platformMessage.getDescription()))
+                .setActionRow(Button.link(roomCreateShortcut, platformMessage.getDescriptionWithEmoji()))
                 .build();
     }
 
@@ -34,7 +50,7 @@ public class DiscordMessageBuilder {
         final String formattedDeadline = deadline.getStartAt()
                 .format(PlatformMessageStyle.DEFAULT.getDateTimeFormatter());
         final MessageEmbed embed = new EmbedBuilder()
-                .setTitle(platformMessage.getTitle())
+                .setTitle(platformMessage.getTitleWithEmoji())
                 .setDescription(String.format("""
                         > **제목 : ** %s
                         > **마감기한 : ** %s
@@ -44,7 +60,7 @@ public class DiscordMessageBuilder {
 
         return new MessageCreateBuilder()
                 .setEmbeds(embed)
-                .setActionRow(Button.link(shortcut, platformMessage.getDescription()))
+                .setActionRow(Button.link(shortcut, platformMessage.getDescriptionWithEmoji()))
                 .build();
     }
 }

--- a/estime-api/src/main/java/com/estime/room/infrastructure/platform/discord/DiscordMessageSender.java
+++ b/estime-api/src/main/java/com/estime/room/infrastructure/platform/discord/DiscordMessageSender.java
@@ -1,7 +1,7 @@
 package com.estime.room.infrastructure.platform.discord;
 
 import com.estime.room.domain.platform.PlatformMessage;
-import com.estime.room.domain.slot.vo.DateTimeSlot;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.JDA;
@@ -30,7 +30,7 @@ public class DiscordMessageSender {
             final String channelId,
             final String shortcut,
             final String title,
-            final DateTimeSlot deadline
+            final LocalDateTime deadline
     ) {
         final TextChannel channel = getChannel(channelId);
         if (channel == null) {

--- a/estime-api/src/main/java/com/estime/room/infrastructure/platform/discord/DiscordMessageSender.java
+++ b/estime-api/src/main/java/com/estime/room/infrastructure/platform/discord/DiscordMessageSender.java
@@ -44,6 +44,26 @@ public class DiscordMessageSender {
         sendMessage(channel, message);
     }
 
+    public void sendReminderMessage(final String channelId, final String roomTitle) {
+        final TextChannel channel = getChannel(channelId);
+        if (channel == null) {
+            return;
+        }
+
+        final MessageCreateData message = discordMessageBuilder.buildReminderMessage(roomTitle);
+        sendMessage(channel, message);
+    }
+
+    public void sendDeadlineAlertMessage(final String channelId, final String roomTitle) {
+        final TextChannel channel = getChannel(channelId);
+        if (channel == null) {
+            return;
+        }
+
+        final MessageCreateData message = discordMessageBuilder.buildDeadlineAlertMessage(roomTitle);
+        sendMessage(channel, message);
+    }
+
     private TextChannel getChannel(final String channelId) {
         final TextChannel channel = jda.getTextChannelById(channelId);
         if (channel == null) {

--- a/estime-api/src/main/java/com/estime/room/infrastructure/platform/discord/DiscordSlashCommandListener.java
+++ b/estime-api/src/main/java/com/estime/room/infrastructure/platform/discord/DiscordSlashCommandListener.java
@@ -18,6 +18,13 @@ public class DiscordSlashCommandListener extends ListenerAdapter {
 
     @Override
     public void onSlashCommandInteraction(final SlashCommandInteractionEvent event) {
+        if (event.getName().equals(PlatformCommand.HELP.getValue())) {
+            final MessageCreateData messageData = discordMessageBuilder.buildHelpMessage();
+            event.reply(messageData)
+                    .setEphemeral(true)
+                    .queue();
+        }
+
         if (event.getName().equals(PlatformCommand.CREATE.getValue())) {
             final String shortcut = getConnectedRoomCreateUrl(event);
             final MessageCreateData messageData = discordMessageBuilder.buildConnectedRoomCreateMessage(shortcut);

--- a/estime-api/src/main/java/com/estime/room/presentation/dto/request/ConnectedRoomCreateRequest.java
+++ b/estime-api/src/main/java/com/estime/room/presentation/dto/request/ConnectedRoomCreateRequest.java
@@ -4,7 +4,6 @@ import com.estime.room.application.dto.input.ConnectedRoomCreateInput;
 import com.estime.room.domain.platform.PlatformNotification;
 import com.estime.room.domain.platform.PlatformType;
 import com.estime.room.domain.slot.vo.DateSlot;
-import com.estime.room.domain.slot.vo.DateTimeSlot;
 import com.estime.room.domain.slot.vo.TimeSlot;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -42,7 +41,7 @@ public record ConnectedRoomCreateRequest(
                 title,
                 availableDateSlots.stream().map(DateSlot::from).toList(),
                 availableTimeSlots.stream().map(TimeSlot::from).toList(),
-                DateTimeSlot.from(deadline),
+                deadline,
                 PlatformType.from(platformType),
                 channelId,
                 PlatformNotification.of(notification.created, notification.remind, notification.deadline)

--- a/estime-api/src/main/java/com/estime/room/presentation/dto/request/RoomCreateRequest.java
+++ b/estime-api/src/main/java/com/estime/room/presentation/dto/request/RoomCreateRequest.java
@@ -2,7 +2,6 @@ package com.estime.room.presentation.dto.request;
 
 import com.estime.room.application.dto.input.RoomCreateInput;
 import com.estime.room.domain.slot.vo.DateSlot;
-import com.estime.room.domain.slot.vo.DateTimeSlot;
 import com.estime.room.domain.slot.vo.TimeSlot;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -33,7 +32,7 @@ public record RoomCreateRequest(
                 title,
                 availableDateSlots.stream().map(DateSlot::from).toList(),
                 availableTimeSlots.stream().map(TimeSlot::from).toList(),
-                DateTimeSlot.from(deadline)
+                deadline
         );
     }
 }

--- a/estime-api/src/main/java/com/estime/room/presentation/dto/response/RoomResponse.java
+++ b/estime-api/src/main/java/com/estime/room/presentation/dto/response/RoomResponse.java
@@ -34,7 +34,7 @@ public record RoomResponse(
                 output.title(),
                 output.availableDateSlots().stream().map(DateSlot::getStartAt).sorted().toList(),
                 output.availableTimeSlots().stream().map(TimeSlot::getStartAt).sorted().toList(),
-                output.deadline().getStartAt(),
+                output.deadline(),
                 output.session().getValue().toString()
         );
     }

--- a/estime-api/src/test/java/com/estime/room/application/RoomDeadlineSchedulerTest.java
+++ b/estime-api/src/test/java/com/estime/room/application/RoomDeadlineSchedulerTest.java
@@ -1,0 +1,94 @@
+package com.estime.room.application;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.estime.notification.application.NotificationService;
+import com.estime.room.domain.Room;
+import com.estime.room.domain.RoomRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class RoomDeadlineSchedulerTest {
+
+    @Autowired
+    private RoomDeadlineScheduler roomDeadlineScheduler;
+
+    @Autowired
+    private RoomRepository roomRepository;
+
+    @MockitoBean
+    private NotificationService notificationService;
+
+    @Test
+    @DisplayName("초기화 시, 마감 시간이 미래인 기존 방들의 알림 작업이 큐에 등록되고, 시간이 되면 알림을 보낸다")
+    void initialize_schedulesTasksForExistingRooms() throws InterruptedException {
+        // given
+        final LocalDateTime now = LocalDateTime.now();
+        final LocalDateTime deadline = now.plusSeconds(3);
+        final Room roomForDeadline = Room.withoutId("Test Room", List.of(), List.of(), deadline);
+        roomRepository.save(roomForDeadline);
+
+        // when
+        roomDeadlineScheduler.initialize();
+        Thread.sleep(5000); // Wait for deadline to pass
+        roomDeadlineScheduler.processTaskQueue();
+
+        // then
+        verify(notificationService, times(1)).sendDeadlineAlert(roomForDeadline.getId());
+    }
+
+    @Test
+    @DisplayName("새로운 방 폴링 시, 신규 방에 대한 알림 작업이 큐에 등록되고, 시간이 되면 알림을 보낸다")
+    void pollNewRooms_schedulesTasksForNewRooms() throws InterruptedException {
+        // given
+        final LocalDateTime now = LocalDateTime.now();
+        
+        final Room room1 = Room.withoutId("Test Room 1", List.of(), List.of(), now.plusDays(1));
+        roomRepository.save(room1);
+        final Room room2 = Room.withoutId("Test Room 2", List.of(), List.of(), now.plusDays(2));
+        roomRepository.save(room2);
+        roomDeadlineScheduler.initialize();
+
+        final LocalDateTime deadline = now.plusSeconds(3);
+        final Room newRoomForDeadline = Room.withoutId("New Test Room", List.of(), List.of(), deadline);
+        roomRepository.save(newRoomForDeadline);
+
+        // when
+        roomDeadlineScheduler.pollNewRooms();
+        Thread.sleep(5000); // Wait for deadline to pass
+        roomDeadlineScheduler.processTaskQueue();
+
+        // then
+        verify(notificationService, times(1)).sendDeadlineAlert(newRoomForDeadline.getId());
+    }
+
+    @Test
+    @DisplayName("마감 1시간 전에 리마인더 알림을 보낸다")
+    void processTaskQueue_sendsReminderBeforeDeadline() throws InterruptedException {
+        // given
+        final LocalDateTime now = LocalDateTime.now();
+        final LocalDateTime deadline = now.plusHours(1).plusSeconds(3); // 1시간 3초 후
+        final Room room = Room.withoutId("Test Room", List.of(), List.of(), deadline);
+        roomRepository.save(room);
+
+        // when
+        roomDeadlineScheduler.initialize();
+        Thread.sleep(5000);
+        roomDeadlineScheduler.processTaskQueue();
+
+        // then
+        verify(notificationService, times(1)).sendReminderNotification(room.getId());
+        verify(notificationService, never()).sendDeadlineAlert(room.getId()); // 아직 deadline 안됨
+    }
+}

--- a/estime-api/src/test/java/com/estime/room/application/service/RoomApplicationServiceTest.java
+++ b/estime-api/src/test/java/com/estime/room/application/service/RoomApplicationServiceTest.java
@@ -106,7 +106,7 @@ class RoomApplicationServiceTest {
                                 TimeSlot.from(LocalTime.of(11, 0)),
                                 TimeSlot.from(LocalTime.of(11, 30))
                         ),
-                        DateTimeSlot.from(LocalDateTime.of(LocalDate.now().plusDays(3), LocalTime.of(10, 0)))
+                        LocalDateTime.of(LocalDate.now().plusDays(3), LocalTime.of(10, 0))
                 ));
 
         participant1 = participantRepository.save(Participant.withoutId(room.getId(), ParticipantName.from("user1")));
@@ -121,7 +121,7 @@ class RoomApplicationServiceTest {
                 "title",
                 List.of(DateSlot.from(LocalDate.now())),
                 List.of(TimeSlot.from(LocalTime.of(7, 0)), TimeSlot.from(LocalTime.of(20, 0))),
-                DateTimeSlot.from(LocalDateTime.of(2026, 1, 1, 0, 0))
+                LocalDateTime.of(2026, 1, 1, 0, 0)
         );
 
         // when
@@ -372,7 +372,7 @@ class RoomApplicationServiceTest {
                 "title",
                 List.of(DateSlot.from(LocalDate.now())),
                 List.of(TimeSlot.from(LocalTime.of(7, 0)), TimeSlot.from(LocalTime.of(20, 0))),
-                DateTimeSlot.from(LocalDateTime.of(2026, 1, 1, 0, 0)),
+                LocalDateTime.of(2026, 1, 1, 0, 0),
                 PlatformType.DISCORD,
                 "testChannelId",
                 PlatformNotification.of(false, false, false)

--- a/estime-api/src/test/java/com/estime/room/domain/RoomTest.java
+++ b/estime-api/src/test/java/com/estime/room/domain/RoomTest.java
@@ -8,7 +8,6 @@ import com.estime.common.exception.domain.DeadlineOverdueException;
 import com.estime.common.exception.domain.InvalidLengthException;
 import com.estime.common.exception.domain.PastNotAllowedException;
 import com.estime.room.domain.slot.vo.DateSlot;
-import com.estime.room.domain.slot.vo.DateTimeSlot;
 import com.estime.room.domain.slot.vo.TimeSlot;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -22,13 +21,13 @@ class RoomTest {
     private final LocalDateTime now = LocalDateTime.now().withMinute(0).withSecond(0).withNano(0);
     private final DateSlot dateSlot = DateSlot.from(now.toLocalDate().plusDays(1));
     private final TimeSlot timeSlot = TimeSlot.from(LocalTime.of(10, 0));
-    private final DateTimeSlot futureDeadline = DateTimeSlot.from(now.plusDays(1));
-    private final DateTimeSlot pastDeadline = DateTimeSlot.from(now.minusDays(1));
+    private final LocalDateTime futureDeadline = now.plusDays(1);
+    private final LocalDateTime pastDeadline = now.minusDays(1);
 
     @DisplayName("정상적인 값으로 Room 생성 성공")
     @Test
     void createRoom_success() {
-        Room room = Room.withoutId(
+        final Room room = Room.withoutId(
                 "테스트방",
                 List.of(dateSlot),
                 List.of(timeSlot),
@@ -46,7 +45,7 @@ class RoomTest {
     @DisplayName("ensureDeadlineNotPassed - 마감이 지났을 때 예외 발생")
     @Test
     void ensureDeadlineNotPassed_expired_throwException() {
-        Room room = Room.withoutId(
+        final Room room = Room.withoutId(
                 "테스트방",
                 List.of(dateSlot),
                 List.of(timeSlot),
@@ -75,7 +74,7 @@ class RoomTest {
     @DisplayName("ensureDeadlineNotPassed - 아직 마감 전이면 예외 발생 안 함")
     @Test
     void ensureDeadlineNotPassed_notExpired_noException() {
-        Room room = Room.withoutId(
+        final Room room = Room.withoutId(
                 "테스트방",
                 List.of(dateSlot),
                 List.of(timeSlot),


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #470 
- close #480
- close #481

## 📝 작업 내용
디스코드 알림 3, 4번 (독려, 마감)을 진행하며 미뤄진 이슈를 간단히 처리했습니다.

# RoomDeadlineScheduler — 개요

`Room.deadline`을 기준으로 **마감 1시간 전(Reminder)**, **마감 시점(Deadline)** 알림을 자동 예약/발송합니다.

## 핵심 구성
- **Queue**: `PriorityBlockingQueue<NotificationTask>` (실행 시각 기준 정렬)
- **증분 스캔 기준**: `AtomicReference<Long> lastCheckedRoomId`
- **리마인더(독려) 시점**: `deadline - 1h`

## 동작 흐름
1) **빈 초기화 시점** (`@PostConstruct`)
   - 현재 시각(`now`) 이후의 Room을 조회.
   - 각 Room에 대해 `REMIND(> now일 때만)`와 `DEADLINE(> now일 때만)` Task를 큐에 적재.
   - 조회된 Room의 **최대(마지막) ID**를 `lastCheckedRoomId`로 기록.

2) **신규 Room 스캔** (`@Scheduled` 매 5분)
   - `lastCheckedRoomId` 이후(`id > lastCheckedRoomId`)의 Room을 조회해 동일 규칙으로 큐에 추가.
   - 처리 후 **최대 ID 갱신**.

3) **Task 실행** (`@Scheduled` 매 5분)
   - `executionTime ≤ now` 인 Task를 꺼내 처리:
     - `REMIND` → `notificationService.sendReminderNotification(roomId)`
     - `DEADLINE` → `notificationService.sendDeadlineAlert(roomId)`

## 처리 규칙
- `deadline ≤ now` → **스킵**
- `REMIND`는 `deadline - 1h > now`일 때만 큐잉
- 큐/ID 상태는 스레드 안전(`PriorityBlockingQueue`, `AtomicReference`)

## 운영 고려사항
- **재기동 복원**: 부팅 시 전체 재구성으로 누락 최소화
- **타임존**: `LocalDateTime` 사용(서버 TZ 기준)
- **지연 허용치**: 스케줄 주기(5분)만큼 최대 지연 가능
- 단일 서버에서만 적용 가능 (수평적 확장 시, 별도의 아키텍처가 필요)

> 요약: 시작 시 미래 알림을 일괄 큐잉하고, 5분마다 신규 Room을 반영하며, 5분마다 알림을 위한 Task를 실행합니다. 간단한 우선순위 큐 기반으로 안정적인 시간 이벤트 처리를 제공합니다.


## 💬 리뷰 요구사항

알림이 최대 1번만 가는 설계를 했습니다. 혹시 2번 이상 가는 케이스가 보인다면 코멘트 부탁드리겠습니다~

스케줄링 간격에 대한 피드백을 받고 싶습니다. 정답은 없다고 생각합니다!