### PR TITLE
SSE 연결 관리 방식 개선

### DIFF
--- a/estime-api/src/main/java/com/estime/common/exception/GlobalExceptionHandler.java
+++ b/estime-api/src/main/java/com/estime/common/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.async.AsyncRequestTimeoutException;
 
 @Slf4j
 @RestControllerAdvice
@@ -22,6 +23,12 @@ public class GlobalExceptionHandler {
     public CustomApiResponse<Void> handleApplicationException(final ApplicationException e) {
         log.warn(e.getLogMessage());
         return CustomApiResponse.badRequest(e.getUserMessage());
+    }
+
+    @ExceptionHandler(AsyncRequestTimeoutException.class)
+    public void handleAsyncRequestTimeoutException(final AsyncRequestTimeoutException e) {
+        MDC.put("message", e.getMessage());
+        log.debug("Async request timed out");
     }
 
     @ExceptionHandler(Exception.class)

--- a/estime-api/src/main/java/com/estime/common/sse/application/SseSender.java
+++ b/estime-api/src/main/java/com/estime/common/sse/application/SseSender.java
@@ -7,11 +7,13 @@ import com.github.f4b6a3.tsid.TsidCreator;
 import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class SseSender {
 
     private final SseEmitters sseEmitters;
@@ -27,8 +29,9 @@ public class SseSender {
                                 .data(SseResponse.from("ok"))
                 );
             } catch (final IOException e) {
-                throw new RuntimeException(
-                        "Failed to send SSE message for roomSession " + roomSession + ":" + e.getMessage(), e);
+                log.debug("Failed to send SSE message, connection likely closed for roomSession {}: {}", roomSession,
+                        e.getMessage());
+                emitter.completeWithError(e);
             }
         }
     }

--- a/estime-api/src/main/java/com/estime/common/sse/application/SseSubscriptionManager.java
+++ b/estime-api/src/main/java/com/estime/common/sse/application/SseSubscriptionManager.java
@@ -2,13 +2,16 @@ package com.estime.common.sse.application;
 
 import com.estime.common.sse.domain.SseEmitters;
 import com.github.f4b6a3.tsid.Tsid;
+import com.github.f4b6a3.tsid.TsidCreator;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class SseSubscriptionManager {
 
     private static final Duration TIMEOUT_DURATION = Duration.ofMinutes(5);
@@ -27,11 +30,21 @@ public class SseSubscriptionManager {
     }
 
     private String createEmitterId(final Tsid roomSession) {
-        return roomSession.toString() + "_" + System.currentTimeMillis();
+        return roomSession.toString() + "_" + TsidCreator.getTsid();
     }
 
     private void setupLifeCycle(final SseEmitter emitter, final String emitterId) {
-        emitter.onCompletion(() -> sseEmitters.deleteById(emitterId));
-        emitter.onTimeout(() -> sseEmitters.deleteById(emitterId));
+        emitter.onCompletion(() -> {
+            log.debug("SSE emitter completed: {}", emitterId);
+            sseEmitters.deleteById(emitterId);
+        });
+        emitter.onTimeout(() -> {
+            log.debug("SSE emitter timed out: {}", emitterId);
+            sseEmitters.deleteById(emitterId);
+        });
+        emitter.onError((ex) -> {
+            log.debug("SSE emitter error: {}", ex.getMessage());
+            sseEmitters.deleteById(emitterId);
+        });
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #492 

## 📝 작업 내용

**예외 처리 로깅 조정**
- SSE 구독/전송 과정에서 발생하는 정상적인 끊김·타임아웃 상황을 DEBUG 수준으로 기록하도록 로그 레벨을 변경해 운영 잡음 개선
- **변경 전**: `IOException` 발생 시 `RuntimeException`을 던지던 로직
- **변경 후**: `DEBUG` 로그 출력 후 `emitter.completeWithError(e)` 처리로 변경

**`AsyncRequestTimeoutException` 핸들러 추가**
- 전역 예외 핸들러에서 `AsyncRequestTimeoutException` 발생 시 DEBUG 로그만 출력
- MDC에 예외 메시지를 넣어 로그 패턴에서 추적 가능하도록 설정

**SSE Emitter 라이프사이클 로깅 추가**
- `onCompletion` → SSE emitter completed 로그
- `onTimeout` → SSE emitter timed out 로그
- `onError` → SSE emitter error 로그

## 💬 리뷰 요구사항
