### PR TITLE
Platform과 연결되지 않은 Room에 독려/마감 알림 전송 시도 삭제

### DIFF
--- a/estime-api/src/main/java/com/estime/room/domain/platform/PlatformNotification.java
+++ b/estime-api/src/main/java/com/estime/room/domain/platform/PlatformNotification.java
@@ -30,7 +30,7 @@ public class PlatformNotification {
         return switch (type) {
             case PlatformNotificationType.CREATED -> onCreated;
             case PlatformNotificationType.REMIND -> onRemind;
-            case PlatformNotificationType.DEADLINE -> onDeadline;
+            case PlatformNotificationType.SOLVED -> onDeadline;
         };
     }
 }

--- a/estime-api/src/main/java/com/estime/room/domain/platform/PlatformNotificationType.java
+++ b/estime-api/src/main/java/com/estime/room/domain/platform/PlatformNotificationType.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 public enum PlatformNotificationType {
     CREATED("방 생성"),
     REMIND("투표 독려"),
-    DEADLINE("투표 마감");
+    SOLVED("투표 마감, 일정 조율 완료");
 
     private final String description;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #500 

## 📝 작업 내용

Platform과 연결되지 않은 Room에 독려/마감 알림 전송을 하는 것을 수정했습니다.
알림 메시지 전송은 Platform과 연결된 ConncetedRoom만 가능합니다.

## 💬 리뷰 요구사항
