### PR TITLE
과거 `DateSlot`을 가진 `Room` 조회 불가 문제 해결

### DIFF
--- a/estime-api/src/main/java/com/estime/room/application/service/RoomApplicationService.java
+++ b/estime-api/src/main/java/com/estime/room/application/service/RoomApplicationService.java
@@ -2,7 +2,6 @@ package com.estime.room.application.service;
 
 import com.estime.common.DomainTerm;
 import com.estime.common.exception.application.NotFoundException;
-import com.estime.common.exception.domain.PastNotAllowedException;
 import com.estime.common.sse.application.SseService;
 import com.estime.room.application.dto.input.ConnectedRoomCreateInput;
 import com.estime.room.application.dto.input.ParticipantCreateInput;
@@ -27,12 +26,10 @@ import com.estime.room.domain.participant.vote.Votes;
 import com.estime.room.domain.platform.Platform;
 import com.estime.room.domain.platform.PlatformNotificationType;
 import com.estime.room.domain.platform.PlatformRepository;
-import com.estime.room.domain.slot.vo.DateSlot;
 import com.estime.room.domain.slot.vo.DateTimeSlot;
 import com.estime.room.domain.vo.RoomSession;
 import com.estime.room.infrastructure.platform.discord.DiscordMessageSender;
 import com.github.f4b6a3.tsid.Tsid;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
@@ -60,14 +57,12 @@ public class RoomApplicationService {
 
     @Transactional
     public RoomCreateOutput createRoom(final RoomCreateInput input) {
-        validateAvailableDateSlots(input.availableDateSlots());
         return RoomCreateOutput.from(roomRepository.save(input.toEntity()));
     }
 
     @Transactional
     public ConnectedRoomCreateOutput createConnectedRoom(final ConnectedRoomCreateInput input) {
         final RoomCreateInput roomCreateInput = input.toRoomCreateInput();
-        validateAvailableDateSlots(roomCreateInput.availableDateSlots());
         final Room room = roomRepository.save(roomCreateInput.toEntity());
 
         final Platform platform = platformRepository.save(
@@ -174,14 +169,6 @@ public class RoomApplicationService {
         }
 
         return ParticipantCheckOutput.from(isDuplicateName);
-    }
-
-    private void validateAvailableDateSlots(final List<DateSlot> availableDateSlots) {
-        for (final DateSlot availableDateSlot : availableDateSlots) {
-            if (availableDateSlot.getStartAt().isBefore(LocalDate.now())) {
-                throw new PastNotAllowedException(DomainTerm.DATE_SLOT, availableDateSlot.getStartAt());
-            }
-        }
     }
 
     private Room obtainRoomBySession(final RoomSession session) {

--- a/estime-api/src/main/java/com/estime/room/application/service/RoomApplicationService.java
+++ b/estime-api/src/main/java/com/estime/room/application/service/RoomApplicationService.java
@@ -2,6 +2,7 @@ package com.estime.room.application.service;
 
 import com.estime.common.DomainTerm;
 import com.estime.common.exception.application.NotFoundException;
+import com.estime.common.exception.domain.PastNotAllowedException;
 import com.estime.common.sse.application.SseService;
 import com.estime.room.application.dto.input.ConnectedRoomCreateInput;
 import com.estime.room.application.dto.input.ParticipantCreateInput;
@@ -26,11 +27,12 @@ import com.estime.room.domain.participant.vote.Votes;
 import com.estime.room.domain.platform.Platform;
 import com.estime.room.domain.platform.PlatformNotificationType;
 import com.estime.room.domain.platform.PlatformRepository;
+import com.estime.room.domain.slot.vo.DateSlot;
 import com.estime.room.domain.slot.vo.DateTimeSlot;
 import com.estime.room.domain.vo.RoomSession;
-import com.estime.room.infrastructure.platform.PlatformShortcutBuilder;
 import com.estime.room.infrastructure.platform.discord.DiscordMessageSender;
 import com.github.f4b6a3.tsid.Tsid;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
@@ -58,15 +60,15 @@ public class RoomApplicationService {
 
     @Transactional
     public RoomCreateOutput createRoom(final RoomCreateInput input) {
-        return RoomCreateOutput.from(
-                roomRepository.save(
-                        input.toEntity()));
+        validateAvailableDateSlots(input.availableDateSlots());
+        return RoomCreateOutput.from(roomRepository.save(input.toEntity()));
     }
 
     @Transactional
     public ConnectedRoomCreateOutput createConnectedRoom(final ConnectedRoomCreateInput input) {
-        final Room room = roomRepository.save(
-                input.toRoomCreateInput().toEntity());
+        final RoomCreateInput roomCreateInput = input.toRoomCreateInput();
+        validateAvailableDateSlots(roomCreateInput.availableDateSlots());
+        final Room room = roomRepository.save(roomCreateInput.toEntity());
 
         final Platform platform = platformRepository.save(
                 Platform.withoutId(
@@ -172,6 +174,14 @@ public class RoomApplicationService {
         }
 
         return ParticipantCheckOutput.from(isDuplicateName);
+    }
+
+    private void validateAvailableDateSlots(final List<DateSlot> availableDateSlots) {
+        for (final DateSlot availableDateSlot : availableDateSlots) {
+            if (availableDateSlot.getStartAt().isBefore(LocalDate.now())) {
+                throw new PastNotAllowedException(DomainTerm.DATE_SLOT, availableDateSlot.getStartAt());
+            }
+        }
     }
 
     private Room obtainRoomBySession(final RoomSession session) {

--- a/estime-api/src/main/java/com/estime/room/domain/Room.java
+++ b/estime-api/src/main/java/com/estime/room/domain/Room.java
@@ -21,6 +21,7 @@ import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
@@ -78,6 +79,7 @@ public class Room extends BaseEntity {
         validateNull(title, availableDateSlots, availableTimeSlots, deadline);
         final String trimmedTitle = title.trim();
         validateTitle(trimmedTitle);
+        validateAvailableDateSlots(availableDateSlots);
         validateDeadline(deadline);
         return new Room(
                 RoomSession.generate(),
@@ -105,6 +107,14 @@ public class Room extends BaseEntity {
     private static void validateTitle(final String trimmedTitle) {
         if (trimmedTitle.isBlank() || trimmedTitle.length() > TITLE_MAX_LENGTH) {
             throw new InvalidLengthException(DomainTerm.ROOM, trimmedTitle);
+        }
+    }
+
+    private static void validateAvailableDateSlots(final List<DateSlot> availableDateSlots) {
+        for (final DateSlot availableDateSlot : availableDateSlots) {
+            if (availableDateSlot.getStartAt().isBefore(LocalDate.now())) {
+                throw new PastNotAllowedException(DomainTerm.DATE_SLOT, availableDateSlot.getStartAt());
+            }
         }
     }
 

--- a/estime-api/src/main/java/com/estime/room/domain/slot/vo/DateSlot.java
+++ b/estime-api/src/main/java/com/estime/room/domain/slot/vo/DateSlot.java
@@ -1,9 +1,6 @@
 package com.estime.room.domain.slot.vo;
 
-import com.estime.common.DomainTerm;
-import com.estime.common.exception.domain.PastNotAllowedException;
 import com.estime.common.util.Validator;
-import java.time.Duration;
 import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -17,13 +14,10 @@ import lombok.ToString;
 @EqualsAndHashCode
 public class DateSlot implements Comparable<DateSlot> {
 
-    public static final Duration UNIT = Duration.ofDays(1);
-
     private final LocalDate startAt;
 
     public static DateSlot from(final LocalDate startAt) {
         validateNull(startAt);
-        validateStartAt(startAt);
         return new DateSlot(startAt);
     }
 
@@ -31,12 +25,6 @@ public class DateSlot implements Comparable<DateSlot> {
         Validator.builder()
                 .add("startAt", startAt)
                 .validateNull();
-    }
-
-    private static void validateStartAt(final LocalDate startAt) {
-        if (startAt.isBefore(LocalDate.now())) {
-            throw new PastNotAllowedException(DomainTerm.DATE_SLOT, startAt);
-        }
     }
 
     @Override

--- a/estime-api/src/test/java/com/estime/room/application/RoomDeadlineSchedulerTest.java
+++ b/estime-api/src/test/java/com/estime/room/application/RoomDeadlineSchedulerTest.java
@@ -1,6 +1,5 @@
 package com.estime.room.application;
 
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -14,7 +13,6 @@ import com.estime.room.domain.platform.PlatformRepository;
 import com.estime.room.domain.platform.PlatformType;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,15 +36,15 @@ class RoomDeadlineSchedulerTest {
     @MockitoBean
     private NotificationService notificationService;
 
-    @Test
     @DisplayName("초기화 시, 마감 시간이 미래인 기존 방들의 알림 작업이 큐에 등록되고, 시간이 되면 알림을 보낸다")
+    @Test
     void initialize_schedulesTasksForExistingRooms() throws InterruptedException {
         // given
         final LocalDateTime now = LocalDateTime.now();
         final LocalDateTime deadline = now.plusSeconds(3);
         final Room roomForDeadline = Room.withoutId("Test Room", List.of(), List.of(), deadline);
         roomRepository.save(roomForDeadline);
-        
+
         final PlatformNotification notification = PlatformNotification.of(false, true, true);
         final Platform platform = Platform.withoutId(
                 roomForDeadline.getId(),
@@ -65,12 +63,12 @@ class RoomDeadlineSchedulerTest {
         verify(notificationService, times(1)).sendDeadlineAlert(roomForDeadline.getId());
     }
 
-    @Test
     @DisplayName("새로운 방 폴링 시, 신규 방에 대한 알림 작업이 큐에 등록되고, 시간이 되면 알림을 보낸다")
+    @Test
     void pollNewRooms_schedulesTasksForNewRooms() throws InterruptedException {
         // given
         final LocalDateTime now = LocalDateTime.now();
-        
+
         final Room room1 = Room.withoutId("Test Room 1", List.of(), List.of(), now.plusDays(1));
         roomRepository.save(room1);
         final Room room2 = Room.withoutId("Test Room 2", List.of(), List.of(), now.plusDays(2));
@@ -80,7 +78,7 @@ class RoomDeadlineSchedulerTest {
         final LocalDateTime deadline = now.plusSeconds(3);
         final Room newRoomForDeadline = Room.withoutId("New Test Room", List.of(), List.of(), deadline);
         roomRepository.save(newRoomForDeadline);
-        
+
         final PlatformNotification notification = PlatformNotification.of(false, true, true);
         final Platform platform = Platform.withoutId(
                 newRoomForDeadline.getId(),
@@ -99,15 +97,15 @@ class RoomDeadlineSchedulerTest {
         verify(notificationService, times(1)).sendDeadlineAlert(newRoomForDeadline.getId());
     }
 
-    @Test
     @DisplayName("마감 1시간 전에 리마인더 알림을 보낸다")
+    @Test
     void processTaskQueue_sendsReminderBeforeDeadline() throws InterruptedException {
         // given
         final LocalDateTime now = LocalDateTime.now();
         final LocalDateTime deadline = now.plusHours(1).plusSeconds(3); // 1시간 3초 후
         final Room room = Room.withoutId("Test Room", List.of(), List.of(), deadline);
         roomRepository.save(room);
-        
+
         final PlatformNotification notification = PlatformNotification.of(false, true, true);
         final Platform platform = Platform.withoutId(
                 room.getId(),
@@ -127,15 +125,15 @@ class RoomDeadlineSchedulerTest {
         verify(notificationService, never()).sendDeadlineAlert(room.getId()); // 아직 deadline 안됨
     }
 
-    @Test
     @DisplayName("플랫폼과 연결된 방에만 알림을 전송한다")
+    @Test
     void processTaskQueue_sendsNotificationOnlyToPlatformConnectedRooms() throws InterruptedException {
         // given
         final LocalDateTime now = LocalDateTime.now();
         final LocalDateTime deadline = now.plusSeconds(3);
         final Room roomWithPlatform = Room.withoutId("Room with Platform", List.of(), List.of(), deadline);
         roomRepository.save(roomWithPlatform);
-        
+
         final PlatformNotification notification = PlatformNotification.of(false, true, true);
         final Platform platform = Platform.withoutId(
                 roomWithPlatform.getId(),
@@ -154,15 +152,15 @@ class RoomDeadlineSchedulerTest {
         verify(notificationService, times(1)).sendDeadlineAlert(roomWithPlatform.getId());
     }
 
-    @Test
     @DisplayName("플랫폼과 연결되지 않은 방에는 알림을 전송하지 않는다")
+    @Test
     void processTaskQueue_skipsNotificationForRoomsWithoutPlatform() throws InterruptedException {
         // given
         final LocalDateTime now = LocalDateTime.now();
         final LocalDateTime deadline = now.plusSeconds(3);
         final Room roomWithoutPlatform = Room.withoutId("Room no Platform", List.of(), List.of(), deadline);
         roomRepository.save(roomWithoutPlatform);
-        
+
         // 플랫폼을 등록하지 않음 (연결되지 않은 상태)
 
         // when

--- a/estime-api/src/test/java/com/estime/room/application/service/RoomApplicationServiceTest.java
+++ b/estime-api/src/test/java/com/estime/room/application/service/RoomApplicationServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.doNothing;
 
 import com.estime.common.DomainTerm;
 import com.estime.common.exception.application.NotFoundException;
+import com.estime.common.exception.domain.PastNotAllowedException;
 import com.estime.common.exception.domain.UnavailableSlotException;
 import com.estime.room.application.dto.input.ConnectedRoomCreateInput;
 import com.estime.room.application.dto.input.ParticipantCreateInput;
@@ -119,9 +120,9 @@ class RoomApplicationServiceTest {
         // given
         final RoomCreateInput input = new RoomCreateInput(
                 "title",
-                List.of(DateSlot.from(LocalDate.now())),
+                List.of(DateSlot.from(LocalDate.now().plusDays(1))),
                 List.of(TimeSlot.from(LocalTime.of(7, 0)), TimeSlot.from(LocalTime.of(20, 0))),
-                LocalDateTime.of(2026, 1, 1, 0, 0)
+                LocalDateTime.now().plusYears(1)
         );
 
         // when
@@ -130,6 +131,23 @@ class RoomApplicationServiceTest {
         // then
         assertThat(isValidSession(saved.session()))
                 .isTrue();
+    }
+
+    @DisplayName("과거 날짜를 포함하는 방을 생성하면 예외가 발생한다.")
+    @Test
+    void createRoom_withPastDate() {
+        // given
+        final RoomCreateInput input = new RoomCreateInput(
+                "title",
+                List.of(DateSlot.from(LocalDate.now().minusDays(1))),
+                List.of(TimeSlot.from(LocalTime.of(7, 0)), TimeSlot.from(LocalTime.of(20, 0))),
+                LocalDateTime.now().plusYears(1)
+        );
+
+        // when & then
+        assertThatThrownBy(() -> roomApplicationService.createRoom(input))
+                .isInstanceOf(com.estime.common.exception.domain.PastNotAllowedException.class)
+                .hasMessageContaining(DomainTerm.DATE_SLOT + " cannot be past");
     }
 
     @DisplayName("세션을 기반으로 방을 조회할 수 있다.")
@@ -370,9 +388,9 @@ class RoomApplicationServiceTest {
         // given
         final ConnectedRoomCreateInput input = new ConnectedRoomCreateInput(
                 "title",
-                List.of(DateSlot.from(LocalDate.now())),
+                List.of(DateSlot.from(LocalDate.now().plusDays(1))),
                 List.of(TimeSlot.from(LocalTime.of(7, 0)), TimeSlot.from(LocalTime.of(20, 0))),
-                LocalDateTime.of(2026, 1, 1, 0, 0),
+                LocalDateTime.now().plusYears(1),
                 PlatformType.DISCORD,
                 "testChannelId",
                 PlatformNotification.of(false, false, false)
@@ -393,6 +411,29 @@ class RoomApplicationServiceTest {
                     .isPresent();
         });
     }
+
+    @DisplayName("과거 날짜를 포함하는 플랫폼과 연결된 방을 생성하면 예외가 발생한다.")
+    @Test
+    void createConnectedRoom_withPastDate() {
+        // given
+        final ConnectedRoomCreateInput input = new ConnectedRoomCreateInput(
+                "title",
+                List.of(DateSlot.from(LocalDate.now().minusDays(1))),
+                List.of(TimeSlot.from(LocalTime.of(7, 0)), TimeSlot.from(LocalTime.of(20, 0))),
+                LocalDateTime.now().plusYears(1),
+                PlatformType.DISCORD,
+                "testChannelId",
+                PlatformNotification.of(false, false, false)
+        );
+
+        doNothing().when(discordMessageSender).sendConnectedRoomCreatedMessage(any(), any(), any(), any());
+
+        // when & then
+        assertThatThrownBy(() -> roomApplicationService.createConnectedRoom(input))
+                .isInstanceOf(PastNotAllowedException.class)
+                .hasMessageContaining(DomainTerm.DATE_SLOT + " cannot be past");
+    }
+
 
     private boolean isValidSession(final RoomSession session) {
         return Tsid.isValid(session.getValue().toString());

--- a/estime-api/src/test/java/com/estime/room/domain/RoomTest.java
+++ b/estime-api/src/test/java/com/estime/room/domain/RoomTest.java
@@ -88,7 +88,7 @@ class RoomTest {
     @Test
     void validateTitle_exceedMaxLength_throwsException() {
         // given
-        String invalidTitle = "제목이 너무 길어서 예외가 발생하는 경우입니다";
+        final String invalidTitle = "제목이 너무 길어서 예외가 발생하는 경우입니다";
 
         // when & then
         assertThatThrownBy(() -> Room.withoutId(
@@ -104,7 +104,7 @@ class RoomTest {
     @Test
     void validateTitle_exactMaxLength_success() {
         // given
-        String exactLengthTitle = "이십글자제목입니다이십글자";
+        final String exactLengthTitle = "이십글자제목입니다이십글자";
 
         // when & then
         assertThatCode(() -> Room.withoutId(
@@ -119,7 +119,7 @@ class RoomTest {
     @Test
     void validateTitle_blank_throwsException() {
         // given
-        String blankTitle = "   ";
+        final String blankTitle = "   ";
 
         // when & then
         assertThatThrownBy(() -> Room.withoutId(

--- a/estime-api/src/test/java/com/estime/room/domain/RoomTest.java
+++ b/estime-api/src/test/java/com/estime/room/domain/RoomTest.java
@@ -2,6 +2,7 @@ package com.estime.room.domain;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.estime.common.DomainTerm;
 import com.estime.common.exception.domain.DeadlineOverdueException;
@@ -12,7 +13,6 @@ import com.estime.room.domain.slot.vo.TimeSlot;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -24,7 +24,7 @@ class RoomTest {
     private final LocalDateTime futureDeadline = now.plusDays(1);
     private final LocalDateTime pastDeadline = now.minusDays(1);
 
-    @DisplayName("정상적인 값으로 Room 생성 성공")
+    @DisplayName("정상적인 값으로 Room 생성을 성공한다")
     @Test
     void createRoom_success() {
         final Room room = Room.withoutId(
@@ -34,7 +34,7 @@ class RoomTest {
                 futureDeadline
         );
 
-        SoftAssertions.assertSoftly(softly -> {
+        assertSoftly(softly -> {
             softly.assertThat(room.getTitle()).isEqualTo("테스트방");
             softly.assertThat(room.getAvailableDateSlots()).containsExactly(dateSlot);
             softly.assertThat(room.getAvailableTimeSlots()).containsExactly(timeSlot);
@@ -42,49 +42,22 @@ class RoomTest {
         });
     }
 
-    @DisplayName("ensureDeadlineNotPassed - 마감이 지났을 때 예외 발생")
+    @DisplayName("제목이 최대 길이(20)와 같으면 예외가 발생하지 않는다")
     @Test
-    void ensureDeadlineNotPassed_expired_throwException() {
-        final Room room = Room.withoutId(
-                "테스트방",
+    void validateTitle_exactMaxLength_noException() {
+        // given
+        final String exactLengthTitle = "이십글자제목입니다이십글자";
+
+        // when & then
+        assertThatCode(() -> Room.withoutId(
+                exactLengthTitle,
                 List.of(dateSlot),
                 List.of(timeSlot),
                 futureDeadline
-        );
-        assertThatThrownBy(() -> room.ensureDeadlineNotPassed(now.plusDays(2)))
-                .isInstanceOf(DeadlineOverdueException.class)
-                .hasMessageContaining(DomainTerm.DEADLINE.name());
+        )).doesNotThrowAnyException();
     }
 
-    @DisplayName("마감기한이 현재 시간 이전이면 PastNotAllowedException 발생")
-    @Test
-    void createRoom_pastDeadline_fail() {
-        assertThatThrownBy(() ->
-                Room.withoutId(
-                        "테스트방",
-                        List.of(dateSlot),
-                        List.of(timeSlot),
-                        pastDeadline
-                )
-        )
-                .isInstanceOf(PastNotAllowedException.class)
-                .hasMessageContaining(DomainTerm.DEADLINE.name());
-    }
-
-    @DisplayName("ensureDeadlineNotPassed - 아직 마감 전이면 예외 발생 안 함")
-    @Test
-    void ensureDeadlineNotPassed_notExpired_noException() {
-        final Room room = Room.withoutId(
-                "테스트방",
-                List.of(dateSlot),
-                List.of(timeSlot),
-                futureDeadline
-        );
-        assertThatCode(() -> room.ensureDeadlineNotPassed(now))
-                .doesNotThrowAnyException();
-    }
-
-    @DisplayName("제목이 최대 길이(20)를 초과하면 InvalidLengthException이 발생한다")
+    @DisplayName("제목이 최대 길이(20)를 초과하면 예외가 발생한다")
     @Test
     void validateTitle_exceedMaxLength_throwsException() {
         // given
@@ -100,22 +73,7 @@ class RoomTest {
                 .hasMessageContaining(DomainTerm.ROOM.name());
     }
 
-    @DisplayName("제목이 최대 길이(20)와 같으면 예외가 발생하지 않는다")
-    @Test
-    void validateTitle_exactMaxLength_success() {
-        // given
-        final String exactLengthTitle = "이십글자제목입니다이십글자";
-
-        // when & then
-        assertThatCode(() -> Room.withoutId(
-                exactLengthTitle,
-                List.of(dateSlot),
-                List.of(timeSlot),
-                futureDeadline
-        )).doesNotThrowAnyException();
-    }
-
-    @DisplayName("제목이 빈 문자열이면 InvalidLengthException이 발생한다")
+    @DisplayName("제목이 빈 문자열이면 예외가 발생한다")
     @Test
     void validateTitle_blank_throwsException() {
         // given
@@ -129,5 +87,88 @@ class RoomTest {
                 futureDeadline
         )).isInstanceOf(InvalidLengthException.class)
                 .hasMessageContaining(DomainTerm.ROOM.name());
+    }
+
+    @DisplayName("마감기한이 현재 시간 이후이면 예외가 발생하지 않는다")
+    @Test
+    void validateDeadline_futureDeadline_noException() {
+        assertThatCode(() -> Room.withoutId(
+                        "테스트방",
+                        List.of(dateSlot),
+                        List.of(timeSlot),
+                        futureDeadline
+        )).doesNotThrowAnyException();
+    }
+
+    @DisplayName("마감기한이 현재 시간 이전이면 예외가 발생한다")
+    @Test
+    void validateDeadline_pastDeadline_throwsException() {
+        assertThatThrownBy(() -> Room.withoutId(
+                        "테스트방",
+                        List.of(dateSlot),
+                        List.of(timeSlot),
+                        pastDeadline
+        )).isInstanceOf(PastNotAllowedException.class)
+                .hasMessageContaining(DomainTerm.DEADLINE.name());
+    }
+
+    @DisplayName("선택 가능한 날짜가 현재 날짜와 같으면 예외가 발생하지 않는다")
+    @Test
+    void validateAvailableDateSlots_today_noException() {
+        // given
+        final DateSlot todayDateSlot = DateSlot.from(now.toLocalDate());
+
+        // when & then
+        assertThatCode(() -> Room.withoutId(
+                "테스트방",
+                List.of(todayDateSlot),
+                List.of(timeSlot),
+                futureDeadline
+        )).doesNotThrowAnyException();
+    }
+
+    @DisplayName("선택 가능한 날짜가 현재 날짜 이전이면 예외가 발생한다")
+    @Test
+    void validateAvailableDateSlots_pastDate_throwsException() {
+        // given
+        final DateSlot pastDateSlot = DateSlot.from(now.toLocalDate().minusDays(1));
+
+        // when & then
+        assertThatThrownBy(() -> Room.withoutId(
+                "테스트방",
+                List.of(pastDateSlot),
+                List.of(timeSlot),
+                futureDeadline
+        )).isInstanceOf(PastNotAllowedException.class)
+                .hasMessageContaining(DomainTerm.DATE_SLOT.name());
+    }
+
+    @DisplayName("마감기한이 지나지 않았을 때 예외가 발생하지 않는다")
+    @Test
+    void ensureDeadlineNotPassed_notExpired_noException() {
+        final Room room = Room.withoutId(
+                "테스트방",
+                List.of(dateSlot),
+                List.of(timeSlot),
+                futureDeadline
+        );
+
+        assertThatCode(() -> room.ensureDeadlineNotPassed(now))
+                .doesNotThrowAnyException();
+    }
+
+    @DisplayName("마감기한이 지났을 때 예외가 발생한다")
+    @Test
+    void ensureDeadlineNotPassed_expired_throwException() {
+        final Room room = Room.withoutId(
+                "테스트방",
+                List.of(dateSlot),
+                List.of(timeSlot),
+                futureDeadline
+        );
+
+        assertThatThrownBy(() -> room.ensureDeadlineNotPassed(now.plusDays(2)))
+                .isInstanceOf(DeadlineOverdueException.class)
+                .hasMessageContaining(DomainTerm.DEADLINE.name());
     }
 }

--- a/estime-api/src/test/java/com/estime/room/domain/participant/vote/VotesTest.java
+++ b/estime-api/src/test/java/com/estime/room/domain/participant/vote/VotesTest.java
@@ -16,8 +16,8 @@ import org.junit.jupiter.api.Test;
 
 class VotesTest {
 
-    @Test
     @DisplayName("정적 팩토리 메소드 from으로 Votes를 생성한다.")
+    @Test
     void from() {
         // given
         final LocalDateTime now = getValidDateTime();
@@ -35,8 +35,8 @@ class VotesTest {
         });
     }
 
-    @Test
     @DisplayName("from 메소드에 null을 전달하면 예외가 발생한다.")
+    @Test
     void from_withNull() {
         // given
         final List<Vote> nullList = null;
@@ -47,8 +47,8 @@ class VotesTest {
                 .hasMessageContaining("cannot be null");
     }
 
-    @Test
     @DisplayName("remove 메소드로 다른 Votes를 제거(차집합)한다.")
+    @Test
     void subtract() {
         // given
         final LocalDateTime now = getValidDateTime();
@@ -68,8 +68,8 @@ class VotesTest {
         });
     }
 
-    @Test
     @DisplayName("calculateStatistic 메소드로 통계를 계산한다.")
+    @Test
     void calculateStatistic() {
         // given
         final LocalDateTime now = getValidDateTime();
@@ -91,8 +91,8 @@ class VotesTest {
         });
     }
 
-    @Test
     @DisplayName("calculateUniqueStartAts 메소드로 중복 없는 시작 시간을 계산한다.")
+    @Test
     void calculateUniqueStartAts() {
         // given
         final LocalDateTime now = getValidDateTime();
@@ -114,8 +114,8 @@ class VotesTest {
         });
     }
 
-    @Test
     @DisplayName("isEmpty와 isNotEmpty 메소드가 올바르게 동작한다.")
+    @Test
     void isEmpty_and_isNotEmpty() {
         // given
         final Votes emptyVotes = Votes.from(Collections.emptyList());

--- a/estime-api/src/test/java/com/estime/room/domain/vo/DateSlotTest.java
+++ b/estime-api/src/test/java/com/estime/room/domain/vo/DateSlotTest.java
@@ -4,9 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
-import com.estime.common.DomainTerm;
 import com.estime.common.exception.domain.NullNotAllowedException;
-import com.estime.common.exception.domain.PastNotAllowedException;
 import com.estime.room.domain.slot.vo.DateSlot;
 import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
@@ -37,18 +35,6 @@ class DateSlotTest {
         assertThatThrownBy(() -> DateSlot.from(nullDate))
                 .isInstanceOf(NullNotAllowedException.class)
                 .hasMessageContaining("cannot be null");
-    }
-
-    @Test
-    @DisplayName("과거 날짜로 DateSlot을 생성하면 예외가 발생한다.")
-    void from_withPastDate() {
-        // given
-        final LocalDate pastDate = LocalDate.now().minusDays(1);
-
-        // when & then
-        assertThatThrownBy(() -> DateSlot.from(pastDate))
-                .isInstanceOf(PastNotAllowedException.class)
-                .hasMessageContaining(DomainTerm.DATE_SLOT + " cannot be past");
     }
 
     @Test

--- a/estime-api/src/test/java/com/estime/room/domain/vo/DateSlotTest.java
+++ b/estime-api/src/test/java/com/estime/room/domain/vo/DateSlotTest.java
@@ -12,8 +12,8 @@ import org.junit.jupiter.api.Test;
 
 class DateSlotTest {
 
-    @Test
     @DisplayName("정적 팩토리 메소드 from으로 DateSlot을 생성한다.")
+    @Test
     void from() {
         // given
         final LocalDate now = LocalDate.now();
@@ -25,8 +25,8 @@ class DateSlotTest {
         assertThat(dateSlot.getStartAt()).isEqualTo(now);
     }
 
-    @Test
     @DisplayName("from 메소드에 null을 전달하면 예외가 발생한다.")
+    @Test
     void from_withNull() {
         // given
         final LocalDate nullDate = null;
@@ -37,8 +37,8 @@ class DateSlotTest {
                 .hasMessageContaining("cannot be null");
     }
 
-    @Test
     @DisplayName("compareTo 메소드로 날짜를 비교한다.")
+    @Test
     void compareTo() {
         // given
         final DateSlot today = DateSlot.from(LocalDate.now());

--- a/estime-api/src/test/java/com/estime/room/domain/vo/DateTimeSlotTest.java
+++ b/estime-api/src/test/java/com/estime/room/domain/vo/DateTimeSlotTest.java
@@ -33,8 +33,8 @@ class DateTimeSlotTest {
         assertThat(dateTimeSlot.getStartAt()).isEqualTo(now);
     }
 
-    @Test
     @DisplayName("from 메소드에 null을 전달하면 예외가 발생한다.")
+    @Test
     void from_withNull() {
         // given
         final LocalDateTime nullDateTime = null;
@@ -45,8 +45,8 @@ class DateTimeSlotTest {
                 .hasMessageContaining("cannot be null");
     }
 
-    @Test
     @DisplayName("30분 단위가 아닌 시간으로 DateTimeSlot을 생성하면 예외가 발생한다.")
+    @Test
     void from_withInvalidMinute() {
         // given
         final LocalDateTime invalidDateTime = getValidDateTime().withMinute(15);
@@ -57,8 +57,8 @@ class DateTimeSlotTest {
                 .hasMessageContaining("must be an interval of 30 minutes");
     }
 
-    @Test
     @DisplayName("isBefore 메소드로 시간을 비교한다.")
+    @Test
     void isBefore() {
         // given
         final DateTimeSlot now = DateTimeSlot.from(getValidDateTime().withMinute(0));
@@ -71,8 +71,8 @@ class DateTimeSlotTest {
         });
     }
 
-    @Test
     @DisplayName("compareTo 메소드로 시간을 비교한다.")
+    @Test
     void compareTo() {
         // given
         final DateTimeSlot now = DateTimeSlot.from(getValidDateTime().withMinute(0));

--- a/estime-api/src/test/java/com/estime/room/domain/vo/TimeSlotTest.java
+++ b/estime-api/src/test/java/com/estime/room/domain/vo/TimeSlotTest.java
@@ -30,8 +30,8 @@ class TimeSlotTest {
         assertThat(timeSlot.getStartAt()).isEqualTo(time);
     }
 
-    @Test
     @DisplayName("from 메소드에 null을 전달하면 예외가 발생한다.")
+    @Test
     void from_withNull() {
         // given
         final LocalTime nullTime = null;
@@ -42,8 +42,8 @@ class TimeSlotTest {
                 .hasMessageContaining("cannot be null");
     }
 
-    @Test
     @DisplayName("초 또는 나노초가 0이 아닌 시간으로 TimeSlot을 생성하면 예외가 발생한다.")
+    @Test
     void from_withSeconds() {
         // given
         final LocalTime invalidTime = LocalTime.of(10, 0, 1);
@@ -54,8 +54,8 @@ class TimeSlotTest {
                 .hasMessageContaining("seconds and nanoseconds must be 0 for");
     }
 
-    @Test
     @DisplayName("30분 단위가 아닌 시간으로 TimeSlot을 생성하면 예외가 발생한다.")
+    @Test
     void from_withInvalidMinute() {
         // given
         final LocalTime invalidTime = LocalTime.of(10, 15);
@@ -66,8 +66,8 @@ class TimeSlotTest {
                 .hasMessageContaining("must be an interval of 30 minutes");
     }
 
-    @Test
     @DisplayName("compareTo 메소드로 시간을 비교한다.")
+    @Test
     void compareTo() {
         // given
         final TimeSlot ten = TimeSlot.from(LocalTime.of(10, 0));


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #510 

## 📝 작업 내용

- `DateSlot.from()`에서 과거 날짜 검증 로직 제거
- 과거 날짜 검증 책임을 `RoomApplicationService`의 `createRoom()`, `createConnectedRoom()` 메서드로 이동
- 새 `Room`/`ConnectedRoom` 생성 시에만 유효성 검사 수행
- DB에서 이미 존재하는 `Room` 조회 시에는 검증하지 않도록 변경
- `RoomApplicationServiceTest`에 과거 날짜로 `Room`/`ConnectedRoom`을 생성할 경우 `PastNotAllowedException`이 발생하는지 확인하는 테스트 코드 추가


## 💬 리뷰 요구사항
