### PR TITLE
[BUILD FAIL] 시간 선호도 API

### DIFF
--- a/estime-api/build.gradle
+++ b/estime-api/build.gradle
@@ -37,9 +37,30 @@ dependencies {
 
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
+
+    // QueryDSL
+    implementation "io.github.openfeign.querydsl:querydsl-jpa:7.0"
+    annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:7.0:jpa"
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
+    testAnnotationProcessor "io.github.openfeign.querydsl:querydsl-apt:7.0:jpa"
+    testAnnotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir layout.buildDirectory.dir("generated/sources/annotationProcessor/java/main")
+        }
+    }
+    test {
+        java {
+            srcDir layout.buildDirectory.dir("generated/sources/annotationProcessor/java/test")
+        }
+    }
 }
 
 tasks.named('test') {
     useJUnitPlatform()
-    workingDir = rootDir // TODO real hard trouble
+    workingDir = rootDir
 }

--- a/estime-api/src/main/java/com/estime/common/DomainTerm.java
+++ b/estime-api/src/main/java/com/estime/common/DomainTerm.java
@@ -14,7 +14,7 @@ public enum DomainTerm {
     VOTE("투표"),
     VOTES("투표들"),
     DEADLINE("마감일"),
-    PLATFORM("플랫폼")
+    PLATFORM("플랫폼"),
     ;
 
     private final String label;

--- a/estime-api/src/main/java/com/estime/common/config/QuerydslConfig.java
+++ b/estime-api/src/main/java/com/estime/common/config/QuerydslConfig.java
@@ -1,0 +1,21 @@
+package com.estime.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/estime-api/src/main/java/com/estime/common/exception/domain/InvalidRangeException.java
+++ b/estime-api/src/main/java/com/estime/common/exception/domain/InvalidRangeException.java
@@ -1,0 +1,24 @@
+package com.estime.common.exception.domain;
+
+import com.estime.common.exception.util.ExceptionMessageFormatter;
+
+public final class InvalidRangeException extends DomainException {
+
+    public InvalidRangeException(final String fieldName, final int value, final int min, final int max) {
+        super(
+                buildLogMessage(fieldName, value, min, max),
+                buildUserMessage(fieldName, min, max)
+        );
+    }
+
+    private static String buildLogMessage(final String fieldName, final int value, final int min, final int max) {
+        return ExceptionMessageFormatter.format(
+                "Invalid range for %s: %d (expected: %d-%d)", 
+                fieldName, value, min, max
+        );
+    }
+
+    private static String buildUserMessage(final String fieldName, final int min, final int max) {
+        return "%s은(는) %d에서 %d 사이의 값이어야 합니다.".formatted(fieldName, min, max);
+    }
+}

--- a/estime-api/src/main/java/com/estime/room/application/port/RoomForTimePreferenceQuery.java
+++ b/estime-api/src/main/java/com/estime/room/application/port/RoomForTimePreferenceQuery.java
@@ -1,0 +1,23 @@
+package com.estime.room.application.port;
+
+import com.estime.room.domain.slot.vo.DateTimeSlot;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+
+public interface RoomForTimePreferenceQuery {
+
+    List<RoomBriefForTimePreference> findBriefs(LocalDate startDate, LocalDate endDate);
+
+    List<VoteCountForTimePreference> findVoteCounts(Collection<Long> roomIds, LocalDate start, LocalDate end);
+
+    record RoomBriefForTimePreference(Long roomId, String title) {
+    }
+
+    record VoteCountForTimePreference(LocalDateTime dateTime, long count) {
+        public VoteCountForTimePreference(final DateTimeSlot slot, final long count) {
+            this(slot.getStartAt(), count);
+        }
+    }
+}

--- a/estime-api/src/main/java/com/estime/room/domain/slot/vo/DateSlot.java
+++ b/estime-api/src/main/java/com/estime/room/domain/slot/vo/DateSlot.java
@@ -13,7 +13,7 @@ import lombok.experimental.FieldNameConstants;
 @Getter
 @ToString
 @EqualsAndHashCode
-@FieldNameConstants
+@FieldNameConstants(level = AccessLevel.PRIVATE)
 public class DateSlot implements Comparable<DateSlot> {
 
     private final LocalDate startAt;

--- a/estime-api/src/main/java/com/estime/room/domain/slot/vo/DateSlot.java
+++ b/estime-api/src/main/java/com/estime/room/domain/slot/vo/DateSlot.java
@@ -7,11 +7,13 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.FieldNameConstants;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 @ToString
 @EqualsAndHashCode
+@FieldNameConstants
 public class DateSlot implements Comparable<DateSlot> {
 
     private final LocalDate startAt;
@@ -23,7 +25,7 @@ public class DateSlot implements Comparable<DateSlot> {
 
     private static void validateNull(final LocalDate startAt) {
         Validator.builder()
-                .add("startAt", startAt)
+                .add(Fields.startAt, startAt)
                 .validateNull();
     }
 

--- a/estime-api/src/main/java/com/estime/room/domain/slot/vo/DateTimeSlot.java
+++ b/estime-api/src/main/java/com/estime/room/domain/slot/vo/DateTimeSlot.java
@@ -10,11 +10,13 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.FieldNameConstants;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @ToString
 @EqualsAndHashCode
+@FieldNameConstants(level = AccessLevel.PRIVATE)
 public class DateTimeSlot implements Comparable<DateTimeSlot> {
 
     public static final Duration UNIT = Duration.ofMinutes(30);
@@ -32,7 +34,7 @@ public class DateTimeSlot implements Comparable<DateTimeSlot> {
 
     private static void validateNull(final LocalDateTime startAt) {
         Validator.builder()
-                .add("startAt", startAt)
+                .add(Fields.startAt, startAt)
                 .validateNull();
     }
 

--- a/estime-api/src/main/java/com/estime/room/infrastructure/RoomForTimePreferenceQueryJpaAdapter.java
+++ b/estime-api/src/main/java/com/estime/room/infrastructure/RoomForTimePreferenceQueryJpaAdapter.java
@@ -7,12 +7,10 @@ import com.estime.room.domain.participant.vote.QVote;
 import com.estime.room.domain.slot.vo.DateSlot;
 import com.estime.room.domain.slot.vo.DateTimeSlot;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 

--- a/estime-api/src/main/java/com/estime/room/infrastructure/RoomForTimePreferenceQueryJpaAdapter.java
+++ b/estime-api/src/main/java/com/estime/room/infrastructure/RoomForTimePreferenceQueryJpaAdapter.java
@@ -1,0 +1,66 @@
+package com.estime.room.infrastructure;
+
+import com.estime.room.application.port.RoomForTimePreferenceQuery;
+import com.estime.room.domain.QRoom;
+import com.estime.room.domain.participant.QParticipant;
+import com.estime.room.domain.participant.vote.QVote;
+import com.estime.room.domain.slot.vo.DateSlot;
+import com.estime.room.domain.slot.vo.DateTimeSlot;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RoomForTimePreferenceQueryJpaAdapter implements RoomForTimePreferenceQuery {
+
+    private final QRoom room = QRoom.room;
+    private final QParticipant participant = QParticipant.participant;
+    private final QVote vote = QVote.vote;
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<RoomBriefForTimePreference> findBriefs(final LocalDate start, final LocalDate end) {
+        return queryFactory
+                .select(Projections.constructor(
+                        RoomBriefForTimePreference.class,
+                        room.id,
+                        room.title))
+                .from(room)
+                .where(room.availableDateSlots.any().between(DateSlot.from(start), DateSlot.from(end)))
+                .fetch();
+    }
+
+    @Override
+    public List<VoteCountForTimePreference> findVoteCounts(
+            final Collection<Long> roomIds,
+            final LocalDate start,
+            final LocalDate end
+    ) {
+        final DateTimeSlot startDateTimeSlot = DateTimeSlot.from(start.atStartOfDay());
+        final DateTimeSlot endDateTimeSlot = DateTimeSlot.from(end.atStartOfDay().plusDays(1).minus(DateTimeSlot.UNIT));
+
+        return queryFactory
+                .select(Projections.constructor(
+                        VoteCountForTimePreference.class,
+                        vote.id.dateTimeSlot,
+                        vote.count()
+                ))
+                .from(room)
+                .join(participant).on(participant.roomId.eq(room.id))
+                .join(vote).on(vote.id.participantId.eq(participant.id))
+                .where(
+                        room.id.in(roomIds),
+                        vote.id.dateTimeSlot.between(startDateTimeSlot, endDateTimeSlot)
+                )
+                .groupBy(vote.id.dateTimeSlot)
+                .fetch();
+    }
+}

--- a/estime-api/src/main/java/com/estime/timepreference/application/RoomCategoryApplicationService.java
+++ b/estime-api/src/main/java/com/estime/timepreference/application/RoomCategoryApplicationService.java
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class RoomCategoryService {
+public class RoomCategoryApplicationService {
 
     private final RoomCategoryRepository roomCategoryRepository;
     private final CategoryClassifier categoryClassifier;

--- a/estime-api/src/main/java/com/estime/timepreference/application/RoomCategoryService.java
+++ b/estime-api/src/main/java/com/estime/timepreference/application/RoomCategoryService.java
@@ -1,0 +1,56 @@
+package com.estime.timepreference.application;
+
+import com.estime.timepreference.domain.category.CategoryClassifier;
+import com.estime.timepreference.domain.category.RoomCategory;
+import com.estime.timepreference.domain.category.RoomCategoryRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RoomCategoryService {
+
+    private final RoomCategoryRepository roomCategoryRepository;
+    private final CategoryClassifier categoryClassifier;
+
+    @Transactional
+    public List<RoomCategory> classifyRooms(final Map<Long, String> titleByRoomId) {
+        if (titleByRoomId == null || titleByRoomId.isEmpty()) {
+            return List.of();
+        }
+
+        final List<RoomCategory> existing =
+                roomCategoryRepository.findAllInRoomId(titleByRoomId.keySet());
+
+        final Set<Long> classifiedRoomId = existing.stream()
+                .map(RoomCategory::getRoomId)
+                .collect(Collectors.toSet());
+
+        final Set<Long> unclassifiedRoomIds = titleByRoomId.keySet().stream()
+                .filter(id -> !classifiedRoomId.contains(id))
+                .collect(Collectors.toSet());
+
+        final List<RoomCategory> categories = unclassifiedRoomIds.stream()
+                .map(id -> RoomCategory.withoutId(
+                        id,
+                        categoryClassifier.classify(
+                                titleByRoomId.get(id))))
+                .toList();
+
+        final List<RoomCategory> saved = roomCategoryRepository.saveAll(categories);
+
+        final List<RoomCategory> result = new ArrayList<>();
+        result.addAll(existing);
+        result.addAll(saved);
+
+        return List.copyOf(result);
+    }
+}

--- a/estime-api/src/main/java/com/estime/timepreference/application/TimePreferenceApplicationService.java
+++ b/estime-api/src/main/java/com/estime/timepreference/application/TimePreferenceApplicationService.java
@@ -29,7 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class TimePreferenceApplicationService {
 
     private final RoomForTimePreferenceQuery roomForTimePreferenceQuery;
-    private final RoomCategoryService roomCategoryService;
+    private final RoomCategoryApplicationService roomCategoryApplicationService;
 
     @Transactional(readOnly = true)
     public TimePreferencesStatisticOutput getTopTimePreferences(final TimePreferenceInput input) {
@@ -44,10 +44,10 @@ public class TimePreferenceApplicationService {
                         RoomBriefForTimePreference::roomId,
                         RoomBriefForTimePreference::title));
 
-        final List<RoomCategory> roomCategories = roomCategoryService.classifyRooms(titleByRoomId);
+        final List<RoomCategory> roomCategories = roomCategoryApplicationService.classifyRooms(titleByRoomId);
 
         final Map<CategoryType, List<Long>> roomIdsByCategory = roomCategories.stream()
-                .filter(each -> each.contains(input.categories()))
+                .filter(each -> each.isInCategories(input.categories()))
                 .collect(Collectors.groupingBy(
                         RoomCategory::getCategory,
                         Collectors.mapping(

--- a/estime-api/src/main/java/com/estime/timepreference/application/TimePreferenceApplicationService.java
+++ b/estime-api/src/main/java/com/estime/timepreference/application/TimePreferenceApplicationService.java
@@ -1,0 +1,102 @@
+package com.estime.timepreference.application;
+
+import com.estime.room.application.port.RoomForTimePreferenceQuery;
+import com.estime.room.application.port.RoomForTimePreferenceQuery.RoomBriefForTimePreference;
+import com.estime.room.application.port.RoomForTimePreferenceQuery.VoteCountForTimePreference;
+import com.estime.timepreference.application.dto.TimePreferenceInput;
+import com.estime.timepreference.application.dto.TimePreferencesStatisticOutput;
+import com.estime.timepreference.application.dto.TimePreferencesStatisticOutput.TimePreferenceOutput;
+import com.estime.timepreference.application.dto.TimePreferencesStatisticOutput.TimePreferencesOutput;
+import com.estime.timepreference.domain.TimeZoneConstants;
+import com.estime.timepreference.domain.category.CategoryType;
+import com.estime.timepreference.domain.category.RoomCategory;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TimePreferenceApplicationService {
+
+    private final RoomForTimePreferenceQuery roomForTimePreferenceQuery;
+    private final RoomCategoryService roomCategoryService;
+
+    @Transactional(readOnly = true)
+    public TimePreferencesStatisticOutput getTopTimePreferences(final TimePreferenceInput input) {
+        final LocalDate endDate = LocalDate.now(TimeZoneConstants.ASIA_SEOUL);
+        final LocalDate startDate = endDate.minusDays(input.windowDays() - 1);
+
+        final List<RoomBriefForTimePreference> roomBriefs =
+                roomForTimePreferenceQuery.findBriefs(startDate, endDate);
+
+        final Map<Long, String> titleByRoomId = roomBriefs.stream()
+                .collect(Collectors.toMap(
+                        RoomBriefForTimePreference::roomId,
+                        RoomBriefForTimePreference::title));
+
+        final List<RoomCategory> roomCategories = roomCategoryService.classifyRooms(titleByRoomId);
+
+        final Map<CategoryType, List<Long>> roomIdsByCategory = roomCategories.stream()
+                .filter(each -> each.contains(input.categories()))
+                .collect(Collectors.groupingBy(
+                        RoomCategory::getCategory,
+                        Collectors.mapping(
+                                RoomCategory::getRoomId,
+                                Collectors.toList())
+                ));
+
+        final List<TimePreferencesOutput> outputs = roomIdsByCategory.entrySet().stream()
+                .map(entry ->
+                        createTimePreferencesOutput(
+                                entry.getKey(),
+                                entry.getValue(),
+                                startDate,
+                                endDate,
+                                input.topN()))
+                .toList();
+
+        return new TimePreferencesStatisticOutput(startDate, endDate, outputs);
+    }
+
+    private TimePreferencesOutput createTimePreferencesOutput(
+            final CategoryType category,
+            final List<Long> roomIds,
+            final LocalDate startDate,
+            final LocalDate endDate,
+            final int topN
+    ) {
+        final List<VoteCountForTimePreference> voteCounts = roomForTimePreferenceQuery.findVoteCounts(
+                roomIds, startDate, endDate);
+
+        final Map<Entry<DayOfWeek, LocalTime>, Long> countByTime = voteCounts.stream()
+                .collect(Collectors.groupingBy(
+                        voteCount ->
+                                Map.entry(
+                                        voteCount.dateTime().getDayOfWeek(),
+                                        voteCount.dateTime().toLocalTime()),
+                        Collectors.summingLong(VoteCountForTimePreference::count)
+                ));
+
+        final List<TimePreferenceOutput> timePreferences = countByTime.entrySet().stream()
+                .sorted(Entry.comparingByValue(Comparator.reverseOrder()))
+                .limit(topN)
+                .map(timeEntry ->
+                        new TimePreferenceOutput(
+                                timeEntry.getKey().getKey(),
+                                timeEntry.getKey().getValue(),
+                                timeEntry.getValue()))
+                .toList();
+
+        return new TimePreferencesOutput(category, timePreferences);
+    }
+}

--- a/estime-api/src/main/java/com/estime/timepreference/application/dto/TimePreferenceInput.java
+++ b/estime-api/src/main/java/com/estime/timepreference/application/dto/TimePreferenceInput.java
@@ -1,0 +1,13 @@
+package com.estime.timepreference.application.dto;
+
+import com.estime.timepreference.domain.category.CategoryType;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+public record TimePreferenceInput(
+        int windowDays,
+        int topN,
+        Set<CategoryType> categories
+) {
+}

--- a/estime-api/src/main/java/com/estime/timepreference/application/dto/TimePreferenceInput.java
+++ b/estime-api/src/main/java/com/estime/timepreference/application/dto/TimePreferenceInput.java
@@ -1,8 +1,6 @@
 package com.estime.timepreference.application.dto;
 
 import com.estime.timepreference.domain.category.CategoryType;
-import java.util.Collection;
-import java.util.List;
 import java.util.Set;
 
 public record TimePreferenceInput(

--- a/estime-api/src/main/java/com/estime/timepreference/application/dto/TimePreferencesStatisticOutput.java
+++ b/estime-api/src/main/java/com/estime/timepreference/application/dto/TimePreferencesStatisticOutput.java
@@ -1,0 +1,27 @@
+package com.estime.timepreference.application.dto;
+
+import com.estime.timepreference.domain.category.CategoryType;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public record TimePreferencesStatisticOutput(
+        LocalDate startDate,
+        LocalDate endDate,
+        List<TimePreferencesOutput> timePreferencesOutputs
+) {
+
+    public record TimePreferencesOutput(
+            CategoryType category,
+            List<TimePreferenceOutput> timePreferences
+    ) {
+    }
+
+    public record TimePreferenceOutput(
+            DayOfWeek dayOfWeek,
+            LocalTime time,
+            long count
+    ) {
+    }
+}

--- a/estime-api/src/main/java/com/estime/timepreference/domain/TimeZoneConstants.java
+++ b/estime-api/src/main/java/com/estime/timepreference/domain/TimeZoneConstants.java
@@ -8,5 +8,4 @@ import lombok.NoArgsConstructor;
 public final class TimeZoneConstants {
 
     public static final ZoneId ASIA_SEOUL = ZoneId.of("Asia/Seoul");
-    public static final String ASIA_SEOUL_STRING = "Asia/Seoul";
 }

--- a/estime-api/src/main/java/com/estime/timepreference/domain/TimeZoneConstants.java
+++ b/estime-api/src/main/java/com/estime/timepreference/domain/TimeZoneConstants.java
@@ -1,0 +1,12 @@
+package com.estime.timepreference.domain;
+
+import java.time.ZoneId;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.NONE)
+public final class TimeZoneConstants {
+
+    public static final ZoneId ASIA_SEOUL = ZoneId.of("Asia/Seoul");
+    public static final String ASIA_SEOUL_STRING = "Asia/Seoul";
+}

--- a/estime-api/src/main/java/com/estime/timepreference/domain/category/CategoryClassifier.java
+++ b/estime-api/src/main/java/com/estime/timepreference/domain/category/CategoryClassifier.java
@@ -1,0 +1,6 @@
+package com.estime.timepreference.domain.category;
+
+public interface CategoryClassifier {
+
+    CategoryType classify(String roomTitle);
+}

--- a/estime-api/src/main/java/com/estime/timepreference/domain/category/CategoryType.java
+++ b/estime-api/src/main/java/com/estime/timepreference/domain/category/CategoryType.java
@@ -1,0 +1,38 @@
+package com.estime.timepreference.domain.category;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum CategoryType {
+
+    WORK("업무"),
+    LEISURE("여가"),
+    SOCIAL("모임"),
+    ETC("기타");
+
+    private final String displayName;
+
+    public static CategoryType from(final String name) {
+        for (final CategoryType categoryType : values()) {
+            if (categoryType.displayName.equals(name)) {
+                return categoryType;
+            }
+        }
+        throw new IllegalArgumentException("Unknown category: " + name);
+    }
+
+    public static Set<CategoryType> fromOrAll(final List<String> names) {
+        if (names == null || names.isEmpty()) {
+            return Set.of(values());
+        }
+        return names.stream()
+                .map(CategoryType::from)
+                .collect(Collectors.toSet());
+    }
+}

--- a/estime-api/src/main/java/com/estime/timepreference/domain/category/CategoryType.java
+++ b/estime-api/src/main/java/com/estime/timepreference/domain/category/CategoryType.java
@@ -1,6 +1,5 @@
 package com.estime.timepreference.domain.category;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/estime-api/src/main/java/com/estime/timepreference/domain/category/RoomCategory.java
+++ b/estime-api/src/main/java/com/estime/timepreference/domain/category/RoomCategory.java
@@ -1,0 +1,44 @@
+package com.estime.timepreference.domain.category;
+
+import com.estime.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Table(name = "room_category", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_room_category_room_id", columnNames = "room_id")
+})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@ToString
+public class RoomCategory extends BaseEntity {
+
+    @Column(name = "room_id", nullable = false)
+    private Long roomId;
+
+    @Column(name = "category", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private CategoryType category;
+
+    public static RoomCategory withoutId(
+            final Long roomId,
+            final CategoryType category
+    ) {
+        return new RoomCategory(roomId, category);
+    }
+
+    public boolean contains(final Set<CategoryType> categories) {
+        return categories.contains(this.category);
+    }
+}

--- a/estime-api/src/main/java/com/estime/timepreference/domain/category/RoomCategory.java
+++ b/estime-api/src/main/java/com/estime/timepreference/domain/category/RoomCategory.java
@@ -38,7 +38,7 @@ public class RoomCategory extends BaseEntity {
         return new RoomCategory(roomId, category);
     }
 
-    public boolean contains(final Set<CategoryType> categories) {
+    public boolean isInCategories(final Set<CategoryType> categories) {
         return categories.contains(this.category);
     }
 }

--- a/estime-api/src/main/java/com/estime/timepreference/domain/category/RoomCategoryRepository.java
+++ b/estime-api/src/main/java/com/estime/timepreference/domain/category/RoomCategoryRepository.java
@@ -1,0 +1,16 @@
+package com.estime.timepreference.domain.category;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface RoomCategoryRepository {
+
+    RoomCategory save(RoomCategory category);
+
+    List<RoomCategory> saveAll(List<RoomCategory> categories);
+
+    Optional<RoomCategory> findByRoomId(Long roomId);
+
+    List<RoomCategory> findAllInRoomId(Collection<Long> roomIds);
+}

--- a/estime-api/src/main/java/com/estime/timepreference/infrastructure/category/KeywordCategoryClassifier.java
+++ b/estime-api/src/main/java/com/estime/timepreference/infrastructure/category/KeywordCategoryClassifier.java
@@ -2,11 +2,10 @@ package com.estime.timepreference.infrastructure.category;
 
 import com.estime.timepreference.domain.category.CategoryClassifier;
 import com.estime.timepreference.domain.category.CategoryType;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
-
 import java.text.Normalizer;
 import java.util.Locale;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
@@ -20,24 +19,17 @@ public class KeywordCategoryClassifier implements CategoryClassifier {
 
         final String title = normalize(rawTitle);
 
-        if (containsWorkKeywords(title))   return CategoryType.WORK;
-        if (containsLeisureKeywords(title)) return CategoryType.LEISURE;
-        if (containsSocialKeywords(title))  return CategoryType.SOCIAL;
+        if (containsWorkKeywords(title)) {
+            return CategoryType.WORK;
+        }
+        if (containsLeisureKeywords(title)) {
+            return CategoryType.LEISURE;
+        }
+        if (containsSocialKeywords(title)) {
+            return CategoryType.SOCIAL;
+        }
 
         return CategoryType.ETC;
-    }
-
-    private static String normalize(final String s) {
-        return Normalizer.normalize(s, Normalizer.Form.NFKC)
-                .toLowerCase(Locale.ROOT)
-                .trim();
-    }
-
-    private static boolean containsAny(final String title, final String... keywords) {
-        for (final String kw : keywords) {
-            if (title.contains(kw)) return true;
-        }
-        return false;
     }
 
     private boolean containsWorkKeywords(final String title) {
@@ -64,5 +56,20 @@ public class KeywordCategoryClassifier implements CategoryClassifier {
         return containsAny(title,
                 "회식", "모임", "파티", "동아리", "친목", "번개"
         );
+    }
+
+    private String normalize(final String s) {
+        return Normalizer.normalize(s, Normalizer.Form.NFKC)
+                .toLowerCase(Locale.ROOT)
+                .trim();
+    }
+
+    private boolean containsAny(final String title, final String... keywords) {
+        for (final String kw : keywords) {
+            if (title.contains(kw)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/estime-api/src/main/java/com/estime/timepreference/infrastructure/category/KeywordCategoryClassifier.java
+++ b/estime-api/src/main/java/com/estime/timepreference/infrastructure/category/KeywordCategoryClassifier.java
@@ -1,0 +1,68 @@
+package com.estime.timepreference.infrastructure.category;
+
+import com.estime.timepreference.domain.category.CategoryClassifier;
+import com.estime.timepreference.domain.category.CategoryType;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.text.Normalizer;
+import java.util.Locale;
+
+@Component
+@Slf4j
+public class KeywordCategoryClassifier implements CategoryClassifier {
+
+    @Override
+    public CategoryType classify(final String rawTitle) {
+        if (rawTitle == null || rawTitle.isBlank()) {
+            return CategoryType.ETC;
+        }
+
+        final String title = normalize(rawTitle);
+
+        if (containsWorkKeywords(title))   return CategoryType.WORK;
+        if (containsLeisureKeywords(title)) return CategoryType.LEISURE;
+        if (containsSocialKeywords(title))  return CategoryType.SOCIAL;
+
+        return CategoryType.ETC;
+    }
+
+    private static String normalize(final String s) {
+        return Normalizer.normalize(s, Normalizer.Form.NFKC)
+                .toLowerCase(Locale.ROOT)
+                .trim();
+    }
+
+    private static boolean containsAny(final String title, final String... keywords) {
+        for (final String kw : keywords) {
+            if (title.contains(kw)) return true;
+        }
+        return false;
+    }
+
+    private boolean containsWorkKeywords(final String title) {
+        return containsAny(title,
+                "회의", "미팅", "스터디", "세미나", "프로젝트",
+                "업무", "작업", "개발",
+                "코딩", "수학", "영어", "회화",
+                "워크숍", "워크샵"
+        );
+    }
+
+    private boolean containsLeisureKeywords(final String title) {
+        return containsAny(title,
+                "게임", "운동", "영화", "취미",
+                "배드민턴", "축구", "농구", "볼링",
+                "쇼핑",
+                "롤", "리그오브레전드", "lol",
+                "배그", "pubg",
+                "오버워치", "overwatch"
+        );
+    }
+
+    private boolean containsSocialKeywords(final String title) {
+        return containsAny(title,
+                "회식", "모임", "파티", "동아리", "친목", "번개"
+        );
+    }
+}

--- a/estime-api/src/main/java/com/estime/timepreference/infrastructure/category/RoomCategoryJpaRepository.java
+++ b/estime-api/src/main/java/com/estime/timepreference/infrastructure/category/RoomCategoryJpaRepository.java
@@ -1,0 +1,10 @@
+package com.estime.timepreference.infrastructure.category;
+
+import com.estime.timepreference.domain.category.RoomCategory;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoomCategoryJpaRepository extends JpaRepository<RoomCategory, Long> {
+
+    Optional<RoomCategory> findByRoomId(Long roomId);
+}

--- a/estime-api/src/main/java/com/estime/timepreference/infrastructure/category/RoomCategoryRepositoryImpl.java
+++ b/estime-api/src/main/java/com/estime/timepreference/infrastructure/category/RoomCategoryRepositoryImpl.java
@@ -1,0 +1,43 @@
+package com.estime.timepreference.infrastructure.category;
+
+import com.estime.timepreference.domain.category.QRoomCategory;
+import com.estime.timepreference.domain.category.RoomCategory;
+import com.estime.timepreference.domain.category.RoomCategoryRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RoomCategoryRepositoryImpl implements RoomCategoryRepository {
+
+    private final RoomCategoryJpaRepository roomCategoryJpaRepository;
+    private final JPAQueryFactory queryFactory;
+    private final QRoomCategory roomCategory = QRoomCategory.roomCategory;
+
+    @Override
+    public RoomCategory save(final RoomCategory category) {
+        return roomCategoryJpaRepository.save(category);
+    }
+
+    @Override
+    public List<RoomCategory> saveAll(final List<RoomCategory> categories) {
+        return roomCategoryJpaRepository.saveAll(categories);
+    }
+
+    @Override
+    public Optional<RoomCategory> findByRoomId(final Long roomId) {
+        return roomCategoryJpaRepository.findByRoomId(roomId);
+    }
+
+    @Override
+    public List<RoomCategory> findAllInRoomId(final Collection<Long> roomIds) {
+        return queryFactory
+                .selectFrom(roomCategory)
+                .where(roomCategory.roomId.in(roomIds))
+                .fetch();
+    }
+}

--- a/estime-api/src/main/java/com/estime/timepreference/presentation/TimePreferenceController.java
+++ b/estime-api/src/main/java/com/estime/timepreference/presentation/TimePreferenceController.java
@@ -7,18 +7,17 @@ import com.estime.timepreference.presentation.dto.TimePreferenceRequest;
 import com.estime.timepreference.presentation.dto.TimePreferenceStatisticResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-public class TimePreferenceController {
+public class TimePreferenceController implements TimePreferenceControllerSpecification {
 
     private final TimePreferenceApplicationService timePreferenceApplicationService;
 
-    @GetMapping("/api/v1/weekly-time-stats")
-    public CustomApiResponse<TimePreferenceStatisticResponse> getWeeklyTimeStats(
+    @Override
+    public CustomApiResponse<TimePreferenceStatisticResponse> getTopTimePreferences(
             @RequestParam(defaultValue = "30") final int windowDays,
             @RequestParam(defaultValue = "3") final int topN,
             @RequestParam(required = false) final List<String> categories

--- a/estime-api/src/main/java/com/estime/timepreference/presentation/TimePreferenceController.java
+++ b/estime-api/src/main/java/com/estime/timepreference/presentation/TimePreferenceController.java
@@ -2,7 +2,6 @@ package com.estime.timepreference.presentation;
 
 import com.estime.common.CustomApiResponse;
 import com.estime.timepreference.application.TimePreferenceApplicationService;
-import com.estime.timepreference.application.dto.TimePreferenceInput;
 import com.estime.timepreference.application.dto.TimePreferencesStatisticOutput;
 import com.estime.timepreference.presentation.dto.TimePreferenceRequest;
 import com.estime.timepreference.presentation.dto.TimePreferenceStatisticResponse;

--- a/estime-api/src/main/java/com/estime/timepreference/presentation/TimePreferenceController.java
+++ b/estime-api/src/main/java/com/estime/timepreference/presentation/TimePreferenceController.java
@@ -1,0 +1,35 @@
+package com.estime.timepreference.presentation;
+
+import com.estime.common.CustomApiResponse;
+import com.estime.timepreference.application.TimePreferenceApplicationService;
+import com.estime.timepreference.application.dto.TimePreferenceInput;
+import com.estime.timepreference.application.dto.TimePreferencesStatisticOutput;
+import com.estime.timepreference.presentation.dto.TimePreferenceRequest;
+import com.estime.timepreference.presentation.dto.TimePreferenceStatisticResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TimePreferenceController {
+
+    private final TimePreferenceApplicationService timePreferenceApplicationService;
+
+    @GetMapping("/api/v1/weekly-time-stats")
+    public CustomApiResponse<TimePreferenceStatisticResponse> getWeeklyTimeStats(
+            @RequestParam(defaultValue = "30") final int windowDays,
+            @RequestParam(defaultValue = "3") final int topN,
+            @RequestParam(required = false) final List<String> categories
+    ) {
+        final TimePreferencesStatisticOutput output = timePreferenceApplicationService.getTopTimePreferences(
+                new TimePreferenceRequest(windowDays, topN, categories).toInput());
+
+        final TimePreferenceStatisticResponse response =
+                TimePreferenceStatisticResponse.of(output);
+
+        return CustomApiResponse.ok(response);
+    }
+}

--- a/estime-api/src/main/java/com/estime/timepreference/presentation/TimePreferenceControllerSpecification.java
+++ b/estime-api/src/main/java/com/estime/timepreference/presentation/TimePreferenceControllerSpecification.java
@@ -1,0 +1,27 @@
+package com.estime.timepreference.presentation;
+
+import com.estime.common.CustomApiResponse;
+import com.estime.timepreference.presentation.dto.TimePreferenceStatisticResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "TimePreference", description = "시간 선호도 API")
+@RequestMapping("/api/v1/time-preferences")
+public interface TimePreferenceControllerSpecification {
+
+    @Operation(summary = "시간 선호도 통계 조회")
+    @GetMapping("/statistics")
+    CustomApiResponse<TimePreferenceStatisticResponse> getTopTimePreferences(
+            @Parameter(description = "조회 기간 (일)", example = "30")
+            @RequestParam(defaultValue = "30") int windowDays,
+            @Parameter(description = "상위 N개", example = "3")
+            @RequestParam(defaultValue = "3") int topN,
+            @Parameter(description = "카테고리 필터", example = "[\"업무\", \"여가\", \"모임\", \"기타\"]")
+            @RequestParam(required = false) List<String> categories
+    );
+}

--- a/estime-api/src/main/java/com/estime/timepreference/presentation/TimePreferenceControllerSpecification.java
+++ b/estime-api/src/main/java/com/estime/timepreference/presentation/TimePreferenceControllerSpecification.java
@@ -17,9 +17,9 @@ public interface TimePreferenceControllerSpecification {
     @Operation(summary = "시간 선호도 통계 조회")
     @GetMapping("/statistics")
     CustomApiResponse<TimePreferenceStatisticResponse> getTopTimePreferences(
-            @Parameter(description = "조회 기간 (일)", example = "30")
+            @Parameter(description = "조회 기간 (일, 1-365)", example = "30")
             @RequestParam(defaultValue = "30") int windowDays,
-            @Parameter(description = "상위 N개", example = "3")
+            @Parameter(description = "상위 N개 (1-100)", example = "3")
             @RequestParam(defaultValue = "3") int topN,
             @Parameter(description = "카테고리 필터", example = "[\"업무\", \"여가\", \"모임\", \"기타\"]")
             @RequestParam(required = false) List<String> categories

--- a/estime-api/src/main/java/com/estime/timepreference/presentation/dto/TimePreferenceRequest.java
+++ b/estime-api/src/main/java/com/estime/timepreference/presentation/dto/TimePreferenceRequest.java
@@ -3,7 +3,6 @@ package com.estime.timepreference.presentation.dto;
 import com.estime.timepreference.application.dto.TimePreferenceInput;
 import com.estime.timepreference.domain.category.CategoryType;
 import java.util.List;
-import java.util.Set;
 
 public record TimePreferenceRequest(
         int windowDays,

--- a/estime-api/src/main/java/com/estime/timepreference/presentation/dto/TimePreferenceRequest.java
+++ b/estime-api/src/main/java/com/estime/timepreference/presentation/dto/TimePreferenceRequest.java
@@ -1,9 +1,12 @@
 package com.estime.timepreference.presentation.dto;
 
+import com.estime.common.exception.domain.InvalidRangeException;
 import com.estime.timepreference.application.dto.TimePreferenceInput;
 import com.estime.timepreference.domain.category.CategoryType;
 import java.util.List;
+import lombok.experimental.FieldNameConstants;
 
+@FieldNameConstants
 public record TimePreferenceRequest(
         int windowDays,
         int topN,
@@ -11,11 +14,11 @@ public record TimePreferenceRequest(
 ) {
 
     public TimePreferenceRequest {
-        if (windowDays <= 0) {
-            windowDays = 30;
+        if (windowDays < 1 || windowDays > 365) {
+            throw new InvalidRangeException(Fields.windowDays, windowDays, 1, 365);
         }
-        if (topN <= 0) {
-            topN = 3;
+        if (topN < 1 || topN > 100) {
+            throw new InvalidRangeException(Fields.topN, topN, 1, 100);
         }
     }
 

--- a/estime-api/src/main/java/com/estime/timepreference/presentation/dto/TimePreferenceRequest.java
+++ b/estime-api/src/main/java/com/estime/timepreference/presentation/dto/TimePreferenceRequest.java
@@ -1,0 +1,26 @@
+package com.estime.timepreference.presentation.dto;
+
+import com.estime.timepreference.application.dto.TimePreferenceInput;
+import com.estime.timepreference.domain.category.CategoryType;
+import java.util.List;
+import java.util.Set;
+
+public record TimePreferenceRequest(
+        int windowDays,
+        int topN,
+        List<String> category
+) {
+
+    public TimePreferenceRequest {
+        if (windowDays <= 0) {
+            windowDays = 30;
+        }
+        if (topN <= 0) {
+            topN = 3;
+        }
+    }
+
+    public TimePreferenceInput toInput() {
+        return new TimePreferenceInput(windowDays, topN, CategoryType.fromOrAll(category));
+    }
+}

--- a/estime-api/src/main/java/com/estime/timepreference/presentation/dto/TimePreferenceStatisticResponse.java
+++ b/estime-api/src/main/java/com/estime/timepreference/presentation/dto/TimePreferenceStatisticResponse.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.TextStyle;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
@@ -18,32 +17,38 @@ public record TimePreferenceStatisticResponse(
         List<CategoryTop> results
 ) {
 
-    public static TimePreferenceStatisticResponse of(
-            final TimePreferencesStatisticOutput output
-    ) {
-
-        final List<CategoryTop> tops = new ArrayList<>();
-
-        for (final TimePreferencesOutput a : output.timePreferencesOutputs()) {
-
-            final List<TimeSlotCount> counts = new ArrayList<>();
-
-            for (final TimePreferenceOutput e : a.timePreferences()) {
-                counts.add(
-                        new TimeSlotCount(
-                                e.dayOfWeek().getDisplayName(TextStyle.SHORT, Locale.KOREA),
-                                e.time(),
-                                e.count()));
-            }
-
-            tops.add(new CategoryTop(a.category().getDisplayName(), counts));
-
-        }
-
+    public static TimePreferenceStatisticResponse of(final TimePreferencesStatisticOutput output) {
         return new TimePreferenceStatisticResponse(
-                TimeZoneConstants.ASIA_SEOUL_STRING,
+                TimeZoneConstants.ASIA_SEOUL.toString(),
                 new Period(output.startDate(), output.endDate()),
-                tops
+                convertToCategoryTops(output.timePreferencesOutputs())
+        );
+    }
+
+    private static List<CategoryTop> convertToCategoryTops(final List<TimePreferencesOutput> outputs) {
+        return outputs.stream()
+                .map(TimePreferenceStatisticResponse::convertToCategoryTop)
+                .toList();
+    }
+
+    private static CategoryTop convertToCategoryTop(final TimePreferencesOutput output) {
+        return new CategoryTop(
+                output.category().getDisplayName(),
+                convertToTimeSlotCounts(output.timePreferences())
+        );
+    }
+
+    private static List<TimeSlotCount> convertToTimeSlotCounts(final List<TimePreferenceOutput> preferences) {
+        return preferences.stream()
+                .map(TimePreferenceStatisticResponse::convertToTimeSlotCount)
+                .toList();
+    }
+
+    private static TimeSlotCount convertToTimeSlotCount(final TimePreferenceOutput preference) {
+        return new TimeSlotCount(
+                preference.dayOfWeek().getDisplayName(TextStyle.SHORT, Locale.KOREA),
+                preference.time(),
+                preference.count()
         );
     }
 

--- a/estime-api/src/main/java/com/estime/timepreference/presentation/dto/TimePreferenceStatisticResponse.java
+++ b/estime-api/src/main/java/com/estime/timepreference/presentation/dto/TimePreferenceStatisticResponse.java
@@ -1,0 +1,74 @@
+package com.estime.timepreference.presentation.dto;
+
+import com.estime.timepreference.application.dto.TimePreferencesStatisticOutput;
+import com.estime.timepreference.application.dto.TimePreferencesStatisticOutput.TimePreferenceOutput;
+import com.estime.timepreference.application.dto.TimePreferencesStatisticOutput.TimePreferencesOutput;
+import com.estime.timepreference.domain.TimeZoneConstants;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.TextStyle;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+public record TimePreferenceStatisticResponse(
+        String timeZone,
+        Period period,
+        List<CategoryTop> results
+) {
+
+    public static TimePreferenceStatisticResponse of(
+            final TimePreferencesStatisticOutput output
+    ) {
+
+        final List<CategoryTop> tops = new ArrayList<>();
+
+        for (final TimePreferencesOutput a : output.timePreferencesOutputs()) {
+
+            final List<TimeSlotCount> counts = new ArrayList<>();
+
+            for (final TimePreferenceOutput e : a.timePreferences()) {
+                counts.add(
+                        new TimeSlotCount(
+                                e.dayOfWeek().getDisplayName(TextStyle.SHORT, Locale.KOREA),
+                                e.time(),
+                                e.count()));
+            }
+
+            tops.add(new CategoryTop(a.category().getDisplayName(), counts));
+
+        }
+
+        return new TimePreferenceStatisticResponse(
+                TimeZoneConstants.ASIA_SEOUL_STRING,
+                new Period(output.startDate(), output.endDate()),
+                tops
+        );
+    }
+
+    private record Period(
+            @JsonFormat(pattern = "yyyy-MM-dd")
+            LocalDate start,
+
+            @JsonFormat(pattern = "yyyy-MM-dd")
+            LocalDate end
+    ) {
+    }
+
+    private record CategoryTop(
+            String category,
+            List<TimeSlotCount> top
+    ) {
+    }
+
+    private record TimeSlotCount(
+            String dayOfWeek,
+
+            @JsonFormat(pattern = "HH:mm")
+            LocalTime time,
+
+            long count
+    ) {
+    }
+}

--- a/estime-api/src/main/resources/db/manual/manual.sql
+++ b/estime-api/src/main/resources/db/manual/manual.sql
@@ -1,7 +1,9 @@
 -- 1) 제약 조건 이름 변경
 -- MySQL에서는 직접 이름 변경 불가 → 드롭 후 재생성 필요
-ALTER TABLE connected_room DROP FOREIGN KEY FK_connected_room_room_id;
-ALTER TABLE connected_room DROP INDEX UK_connected_room_room_id;
+ALTER TABLE connected_room
+    DROP FOREIGN KEY FK_connected_room_room_id;
+ALTER TABLE connected_room
+    DROP INDEX UK_connected_room_room_id;
 
 ALTER TABLE connected_room
     ADD CONSTRAINT UK_platform_room_id UNIQUE (room_id),

--- a/estime-api/src/main/resources/db/migration/V5__add_room_category.sql
+++ b/estime-api/src/main/resources/db/migration/V5__add_room_category.sql
@@ -1,0 +1,10 @@
+CREATE TABLE room_category
+(
+    id       BIGINT AUTO_INCREMENT,
+    room_id  BIGINT      NOT NULL,
+    category VARCHAR(20) NOT NULL,
+    active   BOOLEAN     NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;

--- a/estime-api/src/test/java/com/estime/room/domain/RoomTest.java
+++ b/estime-api/src/test/java/com/estime/room/domain/RoomTest.java
@@ -93,10 +93,10 @@ class RoomTest {
     @Test
     void validateDeadline_futureDeadline_noException() {
         assertThatCode(() -> Room.withoutId(
-                        "테스트방",
-                        List.of(dateSlot),
-                        List.of(timeSlot),
-                        futureDeadline
+                "테스트방",
+                List.of(dateSlot),
+                List.of(timeSlot),
+                futureDeadline
         )).doesNotThrowAnyException();
     }
 
@@ -104,10 +104,10 @@ class RoomTest {
     @Test
     void validateDeadline_pastDeadline_throwsException() {
         assertThatThrownBy(() -> Room.withoutId(
-                        "테스트방",
-                        List.of(dateSlot),
-                        List.of(timeSlot),
-                        pastDeadline
+                "테스트방",
+                List.of(dateSlot),
+                List.of(timeSlot),
+                pastDeadline
         )).isInstanceOf(PastNotAllowedException.class)
                 .hasMessageContaining(DomainTerm.DEADLINE.name());
     }

--- a/estime-api/src/test/java/com/estime/timepreference/application/TimePreferenceApplicationServiceTest.java
+++ b/estime-api/src/test/java/com/estime/timepreference/application/TimePreferenceApplicationServiceTest.java
@@ -82,12 +82,18 @@ class TimePreferenceApplicationServiceTest {
                 deadline
         ));
 
-        workParticipant1 = participantRepository.save(Participant.withoutId(workRoom.getId(), ParticipantName.from("workUser1")));
-        workParticipant2 = participantRepository.save(Participant.withoutId(workRoom.getId(), ParticipantName.from("workUser2")));
-        leisureParticipant1 = participantRepository.save(Participant.withoutId(leisureRoom.getId(), ParticipantName.from("leisureUser1")));
-        leisureParticipant2 = participantRepository.save(Participant.withoutId(leisureRoom.getId(), ParticipantName.from("leisureUser2")));
-        socialParticipant1 = participantRepository.save(Participant.withoutId(socialRoom.getId(), ParticipantName.from("socialUser1")));
-        socialParticipant2 = participantRepository.save(Participant.withoutId(socialRoom.getId(), ParticipantName.from("socialUser2")));
+        workParticipant1 = participantRepository.save(
+                Participant.withoutId(workRoom.getId(), ParticipantName.from("workUser1")));
+        workParticipant2 = participantRepository.save(
+                Participant.withoutId(workRoom.getId(), ParticipantName.from("workUser2")));
+        leisureParticipant1 = participantRepository.save(
+                Participant.withoutId(leisureRoom.getId(), ParticipantName.from("leisureUser1")));
+        leisureParticipant2 = participantRepository.save(
+                Participant.withoutId(leisureRoom.getId(), ParticipantName.from("leisureUser2")));
+        socialParticipant1 = participantRepository.save(
+                Participant.withoutId(socialRoom.getId(), ParticipantName.from("socialUser1")));
+        socialParticipant2 = participantRepository.save(
+                Participant.withoutId(socialRoom.getId(), ParticipantName.from("socialUser2")));
 
         final DateTimeSlot workMorning = DateTimeSlot.from(LocalDateTime.of(testDate, LocalTime.of(10, 0)));
         final DateTimeSlot workAfternoon = DateTimeSlot.from(LocalDateTime.of(testDate, LocalTime.of(14, 0)));
@@ -167,7 +173,7 @@ class TimePreferenceApplicationServiceTest {
 
             if (workOutput != null && workOutput.timePreferences().size() > 1) {
                 final List<TimePreferenceOutput> timePreferences = workOutput.timePreferences();
-                
+
                 assertSoftly(softly -> {
                     for (int i = 0; i < timePreferences.size() - 1; i++) {
                         softly.assertThat(timePreferences.get(i).count())
@@ -208,7 +214,7 @@ class TimePreferenceApplicationServiceTest {
         final Participant additionalParticipant = participantRepository.save(
                 Participant.withoutId(workRoom.getId(), ParticipantName.from("workUser3"))
         );
-        
+
         final DateTimeSlot sameMorningSlot = DateTimeSlot.from(LocalDateTime.of(testDate, LocalTime.of(10, 0)));
         voteRepository.save(Vote.of(additionalParticipant.getId(), sameMorningSlot));
 
@@ -255,7 +261,8 @@ class TimePreferenceApplicationServiceTest {
     void getTopTimePreferences_correctTimeWindow() {
         // given
         final int windowDays = 7;
-        final TimePreferenceInput input = new TimePreferenceInput(windowDays, 5, Set.of(CategoryType.WORK, CategoryType.LEISURE));
+        final TimePreferenceInput input = new TimePreferenceInput(windowDays, 5,
+                Set.of(CategoryType.WORK, CategoryType.LEISURE));
 
         // when
         final TimePreferencesStatisticOutput result = timePreferenceApplicationService.getTopTimePreferences(input);
@@ -263,7 +270,7 @@ class TimePreferenceApplicationServiceTest {
         // then
         final LocalDate expectedStartDate = LocalDate.now().minusDays(windowDays - 1);
         final LocalDate expectedEndDate = LocalDate.now();
-        
+
         assertSoftly(softly -> {
             softly.assertThat(result.startDate()).isEqualTo(expectedStartDate);
             softly.assertThat(result.endDate()).isEqualTo(expectedEndDate);

--- a/estime-api/src/test/java/com/estime/timepreference/application/TimePreferenceApplicationServiceTest.java
+++ b/estime-api/src/test/java/com/estime/timepreference/application/TimePreferenceApplicationServiceTest.java
@@ -1,0 +1,272 @@
+package com.estime.timepreference.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import com.estime.room.domain.Room;
+import com.estime.room.domain.RoomRepository;
+import com.estime.room.domain.participant.Participant;
+import com.estime.room.domain.participant.ParticipantRepository;
+import com.estime.room.domain.participant.vo.ParticipantName;
+import com.estime.room.domain.participant.vote.Vote;
+import com.estime.room.domain.participant.vote.VoteRepository;
+import com.estime.room.domain.slot.vo.DateSlot;
+import com.estime.room.domain.slot.vo.DateTimeSlot;
+import com.estime.room.domain.slot.vo.TimeSlot;
+import com.estime.timepreference.application.dto.TimePreferenceInput;
+import com.estime.timepreference.application.dto.TimePreferencesStatisticOutput;
+import com.estime.timepreference.application.dto.TimePreferencesStatisticOutput.TimePreferenceOutput;
+import com.estime.timepreference.application.dto.TimePreferencesStatisticOutput.TimePreferencesOutput;
+import com.estime.timepreference.domain.category.CategoryType;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class TimePreferenceApplicationServiceTest {
+
+    @Autowired
+    private TimePreferenceApplicationService timePreferenceApplicationService;
+
+    @Autowired
+    private RoomRepository roomRepository;
+
+    @Autowired
+    private ParticipantRepository participantRepository;
+
+    @Autowired
+    private VoteRepository voteRepository;
+
+    private Room workRoom;
+    private Room leisureRoom;
+    private Room socialRoom;
+    private Participant workParticipant1;
+    private Participant workParticipant2;
+    private Participant leisureParticipant1;
+    private Participant leisureParticipant2;
+    private Participant socialParticipant1;
+    private Participant socialParticipant2;
+
+    @BeforeEach
+    void setUp() {
+        final LocalDate testDate = LocalDate.now().plusDays(1);
+        final LocalDateTime deadline = LocalDateTime.now().plusDays(3);
+
+        workRoom = roomRepository.save(Room.withoutId(
+                "개발 회의",
+                List.of(DateSlot.from(testDate)),
+                List.of(TimeSlot.from(LocalTime.of(10, 0)), TimeSlot.from(LocalTime.of(14, 0))),
+                deadline
+        ));
+
+        leisureRoom = roomRepository.save(Room.withoutId(
+                "배드민턴 게임",
+                List.of(DateSlot.from(testDate)),
+                List.of(TimeSlot.from(LocalTime.of(20, 0))),
+                deadline
+        ));
+
+        socialRoom = roomRepository.save(Room.withoutId(
+                "회식 모임",
+                List.of(DateSlot.from(testDate)),
+                List.of(TimeSlot.from(LocalTime.of(18, 0))),
+                deadline
+        ));
+
+        workParticipant1 = participantRepository.save(Participant.withoutId(workRoom.getId(), ParticipantName.from("workUser1")));
+        workParticipant2 = participantRepository.save(Participant.withoutId(workRoom.getId(), ParticipantName.from("workUser2")));
+        leisureParticipant1 = participantRepository.save(Participant.withoutId(leisureRoom.getId(), ParticipantName.from("leisureUser1")));
+        leisureParticipant2 = participantRepository.save(Participant.withoutId(leisureRoom.getId(), ParticipantName.from("leisureUser2")));
+        socialParticipant1 = participantRepository.save(Participant.withoutId(socialRoom.getId(), ParticipantName.from("socialUser1")));
+        socialParticipant2 = participantRepository.save(Participant.withoutId(socialRoom.getId(), ParticipantName.from("socialUser2")));
+
+        final DateTimeSlot workMorning = DateTimeSlot.from(LocalDateTime.of(testDate, LocalTime.of(10, 0)));
+        final DateTimeSlot workAfternoon = DateTimeSlot.from(LocalDateTime.of(testDate, LocalTime.of(14, 0)));
+        final DateTimeSlot leisureEvening = DateTimeSlot.from(LocalDateTime.of(testDate, LocalTime.of(20, 0)));
+
+        voteRepository.save(Vote.of(workParticipant1.getId(), workMorning));
+        voteRepository.save(Vote.of(workParticipant2.getId(), workMorning));
+        voteRepository.save(Vote.of(workParticipant1.getId(), workAfternoon));
+        voteRepository.save(Vote.of(leisureParticipant1.getId(), leisureEvening));
+    }
+
+    @DisplayName("실제 데이터로 시간 선호도 통계를 성공적으로 조회한다")
+    @Test
+    void getTopTimePreferences_withRealData_success() {
+        // given
+        final int windowDays = 7;
+        final int topN = 5;
+        final Set<CategoryType> categories = Set.of(CategoryType.WORK, CategoryType.LEISURE);
+        final TimePreferenceInput input = new TimePreferenceInput(windowDays, topN, categories);
+
+        // when
+        final TimePreferencesStatisticOutput result = timePreferenceApplicationService.getTopTimePreferences(input);
+
+        // then: 미래 데이터는 현재 시점 기준 과거 윈도우에 포함되지 않으므로 결과가 비어있을 수 있음
+        assertSoftly(softly -> {
+            softly.assertThat(result.startDate()).isNotNull();
+            softly.assertThat(result.endDate()).isNotNull();
+            // 결과가 있다면 유효한 카테고리여야 함
+            if (!result.timePreferencesOutputs().isEmpty()) {
+                result.timePreferencesOutputs().forEach(output -> {
+                    softly.assertThat(output.category()).isIn(CategoryType.WORK, CategoryType.LEISURE);
+                    softly.assertThat(output.timePreferences()).isNotNull();
+                });
+            }
+        });
+    }
+
+    @DisplayName("업무 카테고리만 필터링하여 시간 선호도 통계를 조회한다")
+    @Test
+    void getTopTimePreferences_workCategoryOnly() {
+        // given
+        final Set<CategoryType> workOnlyCategories = Set.of(CategoryType.WORK);
+        final TimePreferenceInput input = new TimePreferenceInput(7, 5, workOnlyCategories);
+
+        // when
+        final TimePreferencesStatisticOutput result = timePreferenceApplicationService.getTopTimePreferences(input);
+
+        // then
+        assertSoftly(softly -> {
+            final boolean hasOnlyWorkCategory = result.timePreferencesOutputs().stream()
+                    .allMatch(output -> output.category() == CategoryType.WORK);
+            softly.assertThat(hasOnlyWorkCategory).isTrue();
+
+            if (!result.timePreferencesOutputs().isEmpty()) {
+                final TimePreferencesOutput workOutput = result.timePreferencesOutputs().getFirst();
+                softly.assertThat(workOutput.category()).isEqualTo(CategoryType.WORK);
+                softly.assertThat(workOutput.timePreferences()).isNotEmpty();
+            }
+        });
+    }
+
+    @DisplayName("투표 수가 많은 순으로 정렬되어 반환한다")
+    @Test
+    void getTopTimePreferences_sortedByVoteCount() {
+        // given
+        final TimePreferenceInput input = new TimePreferenceInput(7, 5, Set.of(CategoryType.WORK));
+
+        // when
+        final TimePreferencesStatisticOutput result = timePreferenceApplicationService.getTopTimePreferences(input);
+
+        // then
+        if (!result.timePreferencesOutputs().isEmpty()) {
+            final TimePreferencesOutput workOutput = result.timePreferencesOutputs().stream()
+                    .filter(output -> output.category() == CategoryType.WORK)
+                    .findFirst()
+                    .orElse(null);
+
+            if (workOutput != null && workOutput.timePreferences().size() > 1) {
+                final List<TimePreferenceOutput> timePreferences = workOutput.timePreferences();
+                
+                assertSoftly(softly -> {
+                    for (int i = 0; i < timePreferences.size() - 1; i++) {
+                        softly.assertThat(timePreferences.get(i).count())
+                                .isGreaterThanOrEqualTo(timePreferences.get(i + 1).count());
+                    }
+                });
+            }
+        }
+    }
+
+    @DisplayName("topN 제한에 따라 상위 N개만 반환한다")
+    @Test
+    void getTopTimePreferences_limitedByTopN() {
+        // given
+        final TimePreferenceInput input = new TimePreferenceInput(7, 1, Set.of(CategoryType.WORK));
+
+        // when
+        final TimePreferencesStatisticOutput result = timePreferenceApplicationService.getTopTimePreferences(input);
+
+        // then
+        if (!result.timePreferencesOutputs().isEmpty()) {
+            final TimePreferencesOutput workOutput = result.timePreferencesOutputs().stream()
+                    .filter(output -> output.category() == CategoryType.WORK)
+                    .findFirst()
+                    .orElse(null);
+
+            if (workOutput != null) {
+                assertThat(workOutput.timePreferences()).hasSizeLessThanOrEqualTo(1);
+            }
+        }
+    }
+
+    @DisplayName("동일한 시간대의 투표는 합산되어 반환한다")
+    @Test
+    void getTopTimePreferences_aggregatesSameTimeSlots() {
+        // given
+        final LocalDate testDate = LocalDate.now().plusDays(1);
+        final Participant additionalParticipant = participantRepository.save(
+                Participant.withoutId(workRoom.getId(), ParticipantName.from("workUser3"))
+        );
+        
+        final DateTimeSlot sameMorningSlot = DateTimeSlot.from(LocalDateTime.of(testDate, LocalTime.of(10, 0)));
+        voteRepository.save(Vote.of(additionalParticipant.getId(), sameMorningSlot));
+
+        final TimePreferenceInput input = new TimePreferenceInput(7, 5, Set.of(CategoryType.WORK));
+
+        // when
+        final TimePreferencesStatisticOutput result = timePreferenceApplicationService.getTopTimePreferences(input);
+
+        // then
+        if (!result.timePreferencesOutputs().isEmpty()) {
+            final TimePreferencesOutput workOutput = result.timePreferencesOutputs().stream()
+                    .filter(output -> output.category() == CategoryType.WORK)
+                    .findFirst()
+                    .orElse(null);
+
+            if (workOutput != null && !workOutput.timePreferences().isEmpty()) {
+                final TimePreferenceOutput morningSlot = workOutput.timePreferences().stream()
+                        .filter(pref -> pref.time().equals(LocalTime.of(10, 0)))
+                        .findFirst()
+                        .orElse(null);
+
+                if (morningSlot != null) {
+                    assertThat(morningSlot.count()).isEqualTo(3L);
+                }
+            }
+        }
+    }
+
+    @DisplayName("해당하지 않는 카테고리로 조회하면 빈 결과를 반환한다")
+    @Test
+    void getTopTimePreferences_nonExistentCategory_returnsEmpty() {
+        // given
+        final TimePreferenceInput input = new TimePreferenceInput(7, 5, Set.of(CategoryType.ETC));
+
+        // when
+        final TimePreferencesStatisticOutput result = timePreferenceApplicationService.getTopTimePreferences(input);
+
+        // then
+        assertThat(result.timePreferencesOutputs()).isEmpty();
+    }
+
+    @DisplayName("시간 윈도우가 정확히 설정된다")
+    @Test
+    void getTopTimePreferences_correctTimeWindow() {
+        // given
+        final int windowDays = 7;
+        final TimePreferenceInput input = new TimePreferenceInput(windowDays, 5, Set.of(CategoryType.WORK, CategoryType.LEISURE));
+
+        // when
+        final TimePreferencesStatisticOutput result = timePreferenceApplicationService.getTopTimePreferences(input);
+
+        // then
+        final LocalDate expectedStartDate = LocalDate.now().minusDays(windowDays - 1);
+        final LocalDate expectedEndDate = LocalDate.now();
+        
+        assertSoftly(softly -> {
+            softly.assertThat(result.startDate()).isEqualTo(expectedStartDate);
+            softly.assertThat(result.endDate()).isEqualTo(expectedEndDate);
+        });
+    }
+}

--- a/estime-api/src/test/java/com/estime/timepreference/domain/category/CategoryTypeTest.java
+++ b/estime-api/src/test/java/com/estime/timepreference/domain/category/CategoryTypeTest.java
@@ -50,6 +50,6 @@ class CategoryTypeTest {
         final List<String> names = List.of("업무", "여가");
         final Set<CategoryType> result = CategoryType.fromOrAll(names);
 
-        assertThat(result).containsExactly(CategoryType.WORK, CategoryType.LEISURE);
+        assertThat(result).contains(CategoryType.WORK, CategoryType.LEISURE);
     }
 }

--- a/estime-api/src/test/java/com/estime/timepreference/domain/category/CategoryTypeTest.java
+++ b/estime-api/src/test/java/com/estime/timepreference/domain/category/CategoryTypeTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -30,17 +31,24 @@ class CategoryTypeTest {
     @Test
     void fromOrAll_emptyOrNullList_returnsAll() {
         assertThat(CategoryType.fromOrAll(null))
-                .containsExactlyInAnyOrder(CategoryType.WORK, CategoryType.LEISURE, CategoryType.SOCIAL, CategoryType.ETC);
-        
+                .containsExactlyInAnyOrder(
+                        CategoryType.WORK,
+                        CategoryType.LEISURE,
+                        CategoryType.SOCIAL,
+                        CategoryType.ETC);
+
         assertThat(CategoryType.fromOrAll(List.of()))
-                .containsExactlyInAnyOrder(CategoryType.WORK, CategoryType.LEISURE, CategoryType.SOCIAL, CategoryType.ETC);
+                .containsExactlyInAnyOrder(CategoryType.WORK,
+                        CategoryType.LEISURE,
+                        CategoryType.SOCIAL,
+                        CategoryType.ETC);
     }
 
     @DisplayName("유효한 이름 목록으로 해당 CategoryType들을 반환한다")
     @Test
     void fromOrAll_validNames_returnsCategoryTypes() {
         final List<String> names = List.of("업무", "여가");
-        final List<CategoryType> result = CategoryType.fromOrAll(names);
+        final Set<CategoryType> result = CategoryType.fromOrAll(names);
 
         assertThat(result).containsExactly(CategoryType.WORK, CategoryType.LEISURE);
     }

--- a/estime-api/src/test/java/com/estime/timepreference/domain/category/CategoryTypeTest.java
+++ b/estime-api/src/test/java/com/estime/timepreference/domain/category/CategoryTypeTest.java
@@ -1,0 +1,47 @@
+package com.estime.timepreference.domain.category;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CategoryTypeTest {
+
+    @DisplayName("유효한 displayName으로 CategoryType을 찾는다")
+    @Test
+    void from_validDisplayName_returnsCategoryType() {
+        assertThat(CategoryType.from("업무")).isEqualTo(CategoryType.WORK);
+        assertThat(CategoryType.from("여가")).isEqualTo(CategoryType.LEISURE);
+        assertThat(CategoryType.from("모임")).isEqualTo(CategoryType.SOCIAL);
+        assertThat(CategoryType.from("기타")).isEqualTo(CategoryType.ETC);
+    }
+
+    @DisplayName("유효하지 않은 displayName으로 예외가 발생한다")
+    @Test
+    void from_invalidDisplayName_throwsException() {
+        assertThatThrownBy(() -> CategoryType.from("존재하지않음"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Unknown category: 존재하지않음");
+    }
+
+    @DisplayName("이름 목록이 비어있거나 null이면 모든 CategoryType을 반환한다")
+    @Test
+    void fromOrAll_emptyOrNullList_returnsAll() {
+        assertThat(CategoryType.fromOrAll(null))
+                .containsExactlyInAnyOrder(CategoryType.WORK, CategoryType.LEISURE, CategoryType.SOCIAL, CategoryType.ETC);
+        
+        assertThat(CategoryType.fromOrAll(List.of()))
+                .containsExactlyInAnyOrder(CategoryType.WORK, CategoryType.LEISURE, CategoryType.SOCIAL, CategoryType.ETC);
+    }
+
+    @DisplayName("유효한 이름 목록으로 해당 CategoryType들을 반환한다")
+    @Test
+    void fromOrAll_validNames_returnsCategoryTypes() {
+        final List<String> names = List.of("업무", "여가");
+        final List<CategoryType> result = CategoryType.fromOrAll(names);
+
+        assertThat(result).containsExactly(CategoryType.WORK, CategoryType.LEISURE);
+    }
+}

--- a/estime-api/src/test/java/com/estime/timepreference/domain/category/RoomCategoryTest.java
+++ b/estime-api/src/test/java/com/estime/timepreference/domain/category/RoomCategoryTest.java
@@ -1,0 +1,37 @@
+package com.estime.timepreference.domain.category;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RoomCategoryTest {
+
+    @DisplayName("정상적인 값으로 RoomCategory 생성을 성공한다")
+    @Test
+    void createRoomCategory_success() {
+        final RoomCategory roomCategory = RoomCategory.withoutId(1L, CategoryType.WORK);
+
+        assertThat(roomCategory.getRoomId()).isEqualTo(1L);
+        assertThat(roomCategory.getCategory()).isEqualTo(CategoryType.WORK);
+    }
+
+    @DisplayName("주어진 카테고리가 포함된 경우 true를 반환한다")
+    @Test
+    void contains_includedCategory_returnsTrue() {
+        final RoomCategory roomCategory = RoomCategory.withoutId(1L, CategoryType.WORK);
+        final Set<CategoryType> categories = Set.of(CategoryType.WORK, CategoryType.LEISURE);
+
+        assertThat(roomCategory.contains(categories)).isTrue();
+    }
+
+    @DisplayName("주어진 카테고리가 포함되지 않은 경우 false를 반환한다")
+    @Test
+    void contains_notIncludedCategory_returnsFalse() {
+        final RoomCategory roomCategory = RoomCategory.withoutId(1L, CategoryType.WORK);
+        final Set<CategoryType> categories = Set.of(CategoryType.LEISURE, CategoryType.SOCIAL);
+
+        assertThat(roomCategory.contains(categories)).isFalse();
+    }
+}

--- a/estime-api/src/test/java/com/estime/timepreference/domain/category/RoomCategoryTest.java
+++ b/estime-api/src/test/java/com/estime/timepreference/domain/category/RoomCategoryTest.java
@@ -19,19 +19,19 @@ class RoomCategoryTest {
 
     @DisplayName("주어진 카테고리가 포함된 경우 true를 반환한다")
     @Test
-    void contains_includedCategory_returnsTrue() {
+    void isCategoryIn_included_returnsTrueCategories() {
         final RoomCategory roomCategory = RoomCategory.withoutId(1L, CategoryType.WORK);
         final Set<CategoryType> categories = Set.of(CategoryType.WORK, CategoryType.LEISURE);
 
-        assertThat(roomCategory.contains(categories)).isTrue();
+        assertThat(roomCategory.isInCategories(categories)).isTrue();
     }
 
     @DisplayName("주어진 카테고리가 포함되지 않은 경우 false를 반환한다")
     @Test
-    void contains_notIncludedCategory_returnsFalse() {
+    void isCategoryIn_notIncluded_returnsFalseCategories() {
         final RoomCategory roomCategory = RoomCategory.withoutId(1L, CategoryType.WORK);
         final Set<CategoryType> categories = Set.of(CategoryType.LEISURE, CategoryType.SOCIAL);
 
-        assertThat(roomCategory.contains(categories)).isFalse();
+        assertThat(roomCategory.isInCategories(categories)).isFalse();
     }
 }

--- a/estime-api/src/test/java/com/estime/timepreference/infrastructure/category/KeywordCategoryClassifierTest.java
+++ b/estime-api/src/test/java/com/estime/timepreference/infrastructure/category/KeywordCategoryClassifierTest.java
@@ -1,0 +1,62 @@
+package com.estime.timepreference.infrastructure.category;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.estime.timepreference.domain.category.CategoryType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class KeywordCategoryClassifierTest {
+
+    private final KeywordCategoryClassifier classifier = new KeywordCategoryClassifier();
+
+    @DisplayName("업무 관련 키워드가 있으면 WORK 카테고리를 반환한다")
+    @Test
+    void classify_workKeywords_returnsWork() {
+        assertThat(classifier.classify("프로젝트 회의")).isEqualTo(CategoryType.WORK);
+        assertThat(classifier.classify("개발 미팅")).isEqualTo(CategoryType.WORK);
+        assertThat(classifier.classify("스터디 모임")).isEqualTo(CategoryType.WORK);
+        assertThat(classifier.classify("코딩 세미나")).isEqualTo(CategoryType.WORK);
+    }
+
+    @DisplayName("여가 관련 키워드가 있으면 LEISURE 카테고리를 반환한다")
+    @Test
+    void classify_leisureKeywords_returnsLeisure() {
+        assertThat(classifier.classify("배드민턴 게임")).isEqualTo(CategoryType.LEISURE);
+        assertThat(classifier.classify("영화 보기")).isEqualTo(CategoryType.LEISURE);
+        assertThat(classifier.classify("롤 게임")).isEqualTo(CategoryType.LEISURE);
+        assertThat(classifier.classify("축구 경기")).isEqualTo(CategoryType.LEISURE);
+    }
+
+    @DisplayName("모임 관련 키워드가 있으면 SOCIAL 카테고리를 반환한다")
+    @Test
+    void classify_socialKeywords_returnsSocial() {
+        assertThat(classifier.classify("회식 자리")).isEqualTo(CategoryType.SOCIAL);
+        assertThat(classifier.classify("동아리 모임")).isEqualTo(CategoryType.SOCIAL);
+        assertThat(classifier.classify("친목 파티")).isEqualTo(CategoryType.SOCIAL);
+        assertThat(classifier.classify("번개 모임")).isEqualTo(CategoryType.SOCIAL);
+    }
+
+    @DisplayName("해당하는 키워드가 없으면 ETC 카테고리를 반환한다")
+    @Test
+    void classify_noMatchingKeywords_returnsEtc() {
+        assertThat(classifier.classify("일반적인 제목")).isEqualTo(CategoryType.ETC);
+        assertThat(classifier.classify("기타 내용")).isEqualTo(CategoryType.ETC);
+    }
+
+    @DisplayName("빈 문자열이나 null이면 ETC 카테고리를 반환한다")
+    @Test
+    void classify_emptyOrNull_returnsEtc() {
+        assertThat(classifier.classify(null)).isEqualTo(CategoryType.ETC);
+        assertThat(classifier.classify("")).isEqualTo(CategoryType.ETC);
+        assertThat(classifier.classify("   ")).isEqualTo(CategoryType.ETC);
+    }
+
+    @DisplayName("대소문자와 공백을 무시하고 분류한다")
+    @Test
+    void classify_ignoreCaseAndSpaces_correctlyClassifies() {
+        assertThat(classifier.classify("  프로젝트  ")).isEqualTo(CategoryType.WORK);
+        assertThat(classifier.classify("MEETING")).isEqualTo(CategoryType.ETC);
+        assertThat(classifier.classify("게임")).isEqualTo(CategoryType.LEISURE);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #489 

## 📝 작업 내용

# [설계 바로가기](https://github.com/woowacourse-teams/2025-estime/wiki/estime-Time-Preference-API)

Time Preference API를 추가합니다.
위 설계 링크를 참고해 주세요.

1) 모듈화 전제 하의 설계 (현재는 단일 모듈)
- 현재 코드는 모듈 분리 전이지만, 분리를 가정하고 작성했습니다.
- 엔티티를 외부로 노출하지 않고 Projection/VO만 반환하도록 경계를 고정했습니다.

2) 쿼리 최소화 vs 캐싱 전략
- DB 쿼리 수를 최소화하려 노력했지만, 완벽히 최적화된 상태는 아닙니다.
- 구현 중 판단: 본 기능은 실시간성 요구가 낮은 지표가 많아, 향후 스케줄러 기반 사전 집계 + 캐시로 바꾸면 더 적합할 것 같습니다!

3) Map/스트림 사용과 가독성 선택
- 중간 결과를 DTO/VO로 모두 캡슐화하면 파일 수가 급증하고, 일급 컬렉션/도메인 전환까지 가려면 시간이 크다고 판단했습니다.
- 그래서 이번 PR은 읽기 쉬운 스트림 + Map 기반으로 구성하고, 후속 PR에서 record/VO로 점진적 치환이 가능하도록 구현했습니다.

4) 카테고리 구분
- 현재는 키워드 기반으로 분류하고 있습니다.
- 추후에 AI를 활용해서 조금 더 정확한 분류로 변경할 수 있습니다.

## 💬 리뷰 요구사항
