### PR TITLE
checkEventpage 잡일들(마감기한, 편집하기 버튼 리펙터링)

### DIFF
--- a/frontend/src/pages/CheckEvent/CheckEventPage.tsx
+++ b/frontend/src/pages/CheckEvent/CheckEventPage.tsx
@@ -49,7 +49,7 @@ const CheckEventPage = () => {
     weightCalculateStrategy,
   });
 
-  const [mode, setMode] = useState<'view' | 'edit'>('view');
+  const [mode, setMode] = useState<'register' | 'edit' | 'save'>('register');
 
   const handleError = useHandleError();
 
@@ -57,7 +57,8 @@ const CheckEventPage = () => {
     try {
       await userAvailabilitySubmit();
       await fetchRoomStatistics(session);
-      setMode('view');
+      // save 모드에서 저장하기를 누르면 edit 모드로 전환
+      setMode('edit');
       pageReset();
     } catch (error) {
       handleError(error, 'switchToViewMode');
@@ -67,7 +68,8 @@ const CheckEventPage = () => {
   const switchToEditMode = async () => {
     if (isLoggedIn) {
       await fetchUserAvailableTime();
-      setMode('edit');
+      // register에서 등록하기를 누르거나, edit에서 수정하기를 누르면 save 모드로 전환
+      setMode('save');
       pageReset();
     } else {
       modalHelpers.login.open();
@@ -75,9 +77,11 @@ const CheckEventPage = () => {
   };
 
   const handleToggleMode = async () => {
-    if (mode === 'edit') {
+    if (mode === 'save') {
+      // save 모드에서 "저장하기" 버튼을 누르면 view 모드(edit)로 전환
       await switchToViewMode();
     } else {
+      // register 모드에서 "등록하기" 또는 edit 모드에서 "수정하기"를 누르면 edit 모드(save)로 전환
       switchToEditMode();
     }
   };
@@ -92,7 +96,7 @@ const CheckEventPage = () => {
       await fetchUserAvailableTime();
       modalHelpers.login.close();
       handleLoggedIn.setTrue();
-      setMode('edit');
+      setMode('save');
       pageReset();
     } catch (error) {
       handleError(error, 'handleLoginSuccess');
@@ -105,7 +109,7 @@ const CheckEventPage = () => {
       modalHelpers.login.close();
       await fetchUserAvailableTime();
       handleLoggedIn.setTrue();
-      setMode('edit');
+      setMode('save');
       pageReset();
     } catch (error) {
       handleError(error, 'handleContinueWithDuplicated');
@@ -170,14 +174,14 @@ const CheckEventPage = () => {
             roomSession={roomInfo.roomSession}
             openCopyModal={modalHelpers.copyLink.open}
           />
-          <S.FlipCard isFlipped={mode !== 'view'}>
+          <S.FlipCard isFlipped={mode === 'save'}>
             {/* view 모드 */}
-            <S.FrontFace isFlipped={mode !== 'view'}>
+            <S.FrontFace isFlipped={mode === 'save'}>
               <S.TimeTableContainer ref={timeTableContainerRef}>
                 <Flex direction="column" gap="var(--gap-8)">
                   <TimeTableHeader
                     name={roomInfo.title}
-                    mode="view"
+                    mode={mode}
                     onToggleEditMode={handleToggleMode}
                     isExpired={isExpired}
                   />
@@ -208,12 +212,12 @@ const CheckEventPage = () => {
             </S.FrontFace>
 
             {/* edit 모드 */}
-            <S.BackFace isFlipped={mode !== 'view'}>
+            <S.BackFace isFlipped={mode === 'save'}>
               <S.TimeTableContainer ref={timeTableContainerRef}>
                 <Flex direction="column" gap="var(--gap-8)">
                   <TimeTableHeader
                     name={userName.value}
-                    mode="edit"
+                    mode={mode}
                     onToggleEditMode={handleToggleMode}
                     isExpired={isExpired}
                   />

--- a/frontend/src/pages/CheckEvent/CheckEventPage.tsx
+++ b/frontend/src/pages/CheckEvent/CheckEventPage.tsx
@@ -30,7 +30,7 @@ const CheckEventPage = () => {
   const theme = useTheme();
   const { addToast } = useToastContext();
 
-  const { roomInfo, session } = useCheckRoomSession();
+  const { roomInfo, session, isExpired } = useCheckRoomSession();
 
   const { modalHelpers } = useModalControl();
 
@@ -139,6 +139,8 @@ const CheckEventPage = () => {
     const cell = (e.target as HTMLElement).closest<HTMLElement>('[data-heatmap-cell]');
     if (!cell) return;
 
+    if (isExpired) return;
+
     addToast({
       type: 'warning',
       message: '시간을 등록하려면 "편집하기"를 눌러주세요',
@@ -177,6 +179,7 @@ const CheckEventPage = () => {
                     name={roomInfo.title}
                     mode="view"
                     onToggleEditMode={handleToggleMode}
+                    isExpired={isExpired}
                   />
                   <Flex direction="column" gap="var(--gap-4)">
                     {theme.isMobile && (
@@ -212,6 +215,7 @@ const CheckEventPage = () => {
                     name={userName.value}
                     mode="edit"
                     onToggleEditMode={handleToggleMode}
+                    isExpired={isExpired}
                   />
                   <Flex direction="column" gap="var(--gap-4)">
                     {theme.isMobile && (

--- a/frontend/src/pages/CheckEvent/components/ExpiryNotice/ExpiryNotice.styled.ts
+++ b/frontend/src/pages/CheckEvent/components/ExpiryNotice/ExpiryNotice.styled.ts
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div<{ show: boolean }>`
+  display: ${({ show }) => (show ? 'flex' : 'none')};
+  background: ${({ theme }) => theme.colors.warningBackground};
+  border: 1px solid ${({ theme }) => theme.colors.warningBorder};
+  padding: 12px;
+  border-radius: 12px;
+  align-items: center;
+  justify-content: center;
+`;

--- a/frontend/src/pages/CheckEvent/components/ExpiryNotice/ExpiryNotice.tsx
+++ b/frontend/src/pages/CheckEvent/components/ExpiryNotice/ExpiryNotice.tsx
@@ -1,0 +1,17 @@
+import * as S from './ExpiryNotice.styled';
+
+interface ExpiryNoticeProps {
+  show: boolean;
+  children: React.ReactNode;
+}
+
+const ExpiryNotice = ({ show, children, ...props }: ExpiryNoticeProps) => {
+  console.log(show);
+  return (
+    <S.Container show={show} {...props}>
+      {children}
+    </S.Container>
+  );
+};
+
+export default ExpiryNotice;

--- a/frontend/src/pages/CheckEvent/components/TimeTableHeader/index.tsx
+++ b/frontend/src/pages/CheckEvent/components/TimeTableHeader/index.tsx
@@ -8,7 +8,7 @@ import { useTheme } from '@emotion/react';
 import ExpiryNotice from '../ExpiryNotice/ExpiryNotice';
 
 //로딩 구현시 saving을 쓰면 됨.
-type HeaderMode = 'view' | 'edit';
+type HeaderMode = 'register' | 'edit' | 'save';
 
 interface Presets {
   title: string;
@@ -19,12 +19,17 @@ interface Presets {
 }
 
 const HeaderPresets: Record<HeaderMode, Presets> = {
-  view: {
+  register: {
     title: `전체 시간표`,
-    description: () => '현재 시간표를 확인해보세요!',
-    cta: '편집하기',
+    description: () => '시간표를 등록해주세요!',
+    cta: '등록하기',
   },
   edit: {
+    title: `전체 시간표`,
+    description: () => '현재 시간표를 확인해보세요!',
+    cta: '수정하기',
+  },
+  save: {
     title: `나의 시간표`,
     description: (name: string, isMobile?: boolean) =>
       isMobile
@@ -44,7 +49,7 @@ interface TimeTableHeaderProps extends ComponentProps<'header'> {
 
 const TimeTableHeader = ({
   name,
-  mode = 'view',
+  mode = 'register',
   onToggleEditMode,
   isLoading,
   isExpired,

--- a/frontend/src/pages/CheckEvent/components/TimeTableHeader/index.tsx
+++ b/frontend/src/pages/CheckEvent/components/TimeTableHeader/index.tsx
@@ -80,7 +80,7 @@ const TimeTableHeader = ({
           disabled={isLoading || isExpired}
           size="small"
         >
-          <Text variant="button" color="text">
+          <Text variant="button" color={isExpired ? 'gray50' : 'text'}>
             {presets.cta}
           </Text>
         </Button>

--- a/frontend/src/pages/CheckEvent/components/TimeTableHeader/index.tsx
+++ b/frontend/src/pages/CheckEvent/components/TimeTableHeader/index.tsx
@@ -5,6 +5,7 @@ import Button from '@/shared/components/Button';
 import Flex from '@/shared/layout/Flex';
 import { ComponentProps } from 'react';
 import { useTheme } from '@emotion/react';
+import ExpiryNotice from '../ExpiryNotice/ExpiryNotice';
 
 //로딩 구현시 saving을 쓰면 됨.
 type HeaderMode = 'view' | 'edit';
@@ -38,6 +39,7 @@ interface TimeTableHeaderProps extends ComponentProps<'header'> {
   mode?: HeaderMode;
   onToggleEditMode: () => void;
   isLoading?: boolean;
+  isExpired: boolean;
 }
 
 const TimeTableHeader = ({
@@ -45,6 +47,7 @@ const TimeTableHeader = ({
   mode = 'view',
   onToggleEditMode,
   isLoading,
+  isExpired,
   ...props
 }: TimeTableHeaderProps) => {
   const presets = HeaderPresets[mode];
@@ -60,12 +63,23 @@ const TimeTableHeader = ({
           {presets.description(name, theme.isMobile)}
         </Text>
       </Flex>
-
-      <Button color="primary" onClick={onToggleEditMode} disabled={isLoading} size="small">
-        <Text variant="button" color="text">
-          {presets.cta}
-        </Text>
-      </Button>
+      <Flex gap="var(--gap-8)">
+        <ExpiryNotice show={isExpired}>
+          <Text variant="body" color="warningText">
+            ⚠️ 마감일이 지났어요. 결과를 확인해주세요!
+          </Text>
+        </ExpiryNotice>
+        <Button
+          color="primary"
+          onClick={onToggleEditMode}
+          disabled={isLoading || isExpired}
+          size="small"
+        >
+          <Text variant="button" color="text">
+            {presets.cta}
+          </Text>
+        </Button>
+      </Flex>
     </S.Container>
   );
 };

--- a/frontend/src/pages/CheckEvent/hooks/useCheckRoomSession.ts
+++ b/frontend/src/pages/CheckEvent/hooks/useCheckRoomSession.ts
@@ -45,11 +45,15 @@ const useCheckRoomSession = () => {
     }
   };
 
+  const deadLineDate = new Date(roomInfo.deadline?.date + 'T' + roomInfo.deadline?.time);
+
+  const isExpired = deadLineDate < new Date();
+
   useEffect(() => {
     fetchSession();
   }, [session]);
 
-  return { roomInfo, session };
+  return { roomInfo, session, isExpired };
 };
 
 export default useCheckRoomSession;

--- a/frontend/src/shared/components/Button/Button.styled.ts
+++ b/frontend/src/shared/components/Button/Button.styled.ts
@@ -22,19 +22,27 @@ export const Container = styled.button<{
   }};
   height: 3rem;
   border-radius: var(--radius-4);
-  border: 1px solid ${({ theme, color }) => theme.colors[color]};
+  border: 1px solid
+    ${({ theme, color, disabled }) => {
+      if (disabled) return theme.colors.gray20;
+      return theme.colors[color];
+    }};
 
   cursor: pointer;
   display: flex;
   justify-content: center;
   align-items: center;
   gap: var(--gap-3);
-  background-color: ${({ theme, selected, color }) =>
-    selected ? theme.colors[color] : theme.colors.background};
+  background-color: ${({ theme, selected, color, disabled }) => {
+    if (selected) return theme.colors[color];
+    if (disabled) return theme.colors.gray20;
+    return theme.colors.background;
+  }};
 
   &:hover {
-    ${({ selected, color, theme }) =>
+    ${({ selected, disabled, color, theme }) =>
       !selected &&
+      !disabled &&
       `background-color: ${color === 'primary' ? theme.colors.plum30 : theme.colors.gray10};
       `}
   }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- closes #524 

## 📝 작업 내용
- [x] 마감기한이 지나면 아예 편집하기 버튼을 비활성화한다.
- [x] 편집하기 라는 워딩이 애매 (등록 → 저장 → 수정)으로 용어를 바꾼다.

<img width="2590" height="820" alt="CleanShot 2025-09-10 at 17 46 22@2x" src="https://github.com/user-attachments/assets/dedc5eea-41f9-4c50-9486-172cc35ef7e2" />

원래 버튼에 마우스를 올리면 툴팁으로 제공하는것을 조금 고민해봤는데요. 아뇨. 누구도 안읽는다고 생각해서. 그냥 이렇게 제공하는게 좋을것 같습니다. 대신 디자인에 대해서는 조금 고민해봐요.

## 💬 리뷰 요구사항
구두로 이야기 했지만, 두가지 중요한 change가 있습니다.
1. 버튼에 disabled 속성이 더 적극적으로 disabled 스타일링을 합니다. eec193f1d034aa425ff7785e4cf342f2514cdede
2. 기존 edit<->view가,  register->save<->edit 으로 바뀌었습니다.

로직 자체는 잘 동작하니 문제는 없겠지만, 유저 플로우는 꼭 테스트를 하는 것을 권장합니다.

그리고 이제 reducer를 도입할때가 슬슬 된것 같습니다 register->save<->edit 같은 경우, 한번 save로 들어가면 edit->save->edit... 이렇게 영원히 고정되는데요. 이 변환 로직이 굉장히 헷갈립니다. reducer로 상태 전이등을 조금더 선언적으로 구현하는 방식을 생각해봅시다.