### PR TITLE
dev - prod 간 flyway 쿼리 스크립트 일치화

### DIFF
--- a/estime-api/src/main/resources/db/migration/V2__connected_room_add_channel_id_and_rename_to_platform.sql
+++ b/estime-api/src/main/resources/db/migration/V2__connected_room_add_channel_id_and_rename_to_platform.sql
@@ -1,21 +1,26 @@
--- 1) channel_id 컬럼 NULL 허용으로 추가
-ALTER TABLE connected_room
-    ADD COLUMN channel_id VARCHAR(255) NULL;
+-- 1) platform 테이블 생성
+CREATE TABLE platform
+(
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    room_id BIGINT NOT NULL,
+    type ENUM ('DISCORD') NOT NULL,
+    channel_id VARCHAR(255) NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY UK_platform_room_id (room_id),
+    CONSTRAINT FK_platform_room_id
+        FOREIGN KEY (room_id)
+        REFERENCES room (id)
+        ON DELETE CASCADE
+        ON UPDATE CASCADE
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
--- 2) 기존 행 더미 값으로 백필
-UPDATE connected_room
-SET channel_id = CONCAT('DUMMY_', id)
-WHERE channel_id IS NULL;
+-- 2) platform에 기존 데이터 삽입
+INSERT INTO platform (id, room_id, type, channel_id)
+    SELECT id,
+           room_id,
+           platform,
+           CONCAT('DUMMY_', id) AS channel_id
+    FROM connected_room
+    WHERE platform = 'DISCORD';
 
--- 3) NOT NULL로 고정
-ALTER TABLE connected_room
-    MODIFY COLUMN channel_id VARCHAR(255) NOT NULL;
-
--- 4) platform → platform_type (ENUM 유지)
-ALTER TABLE connected_room
-    CHANGE COLUMN platform type ENUM('DISCORD') NOT NULL;
-
--- 5) 테이블명 변경
-RENAME TABLE connected_room TO platform;
-
--- 6) manual.sql 수동 실행 #1
+-- 3) manual.sql 수동 실행 #1


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #531 

## 📝 작업 내용

prod에 hotfix로 삽입한 flyway 쿼리 변경 사항을 dev와 동기화합니다. 추후에 rds로 변경한 이후에 dev 스프링 db 유저도 drop 권한을 제거해서 prod 배포 가능 여부를 검증하는 방안을 고려하면 좋을 것 같습니다!

## 💬 리뷰 요구사항
변경은 옮겨온 것이 다라서 제가 로컬에서 테스트는 해보았으나, 시간 여유 되시면 db 컨테이너 초기화 후 로컬에 be/prod로 실행 한 번 한 뒤에 해당 브랜치 spring 실행했을 때, 터지지 않는지 확인해주셔도 좋을 것 같습니다!