### PR TITLE
Repository RUD(Read, Update, Delete) 로직을 QueryDSL로 전환

### DIFF
--- a/estime-api/build.gradle
+++ b/estime-api/build.gradle
@@ -13,6 +13,13 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+
+    annotationProcessor "com.querydsl:querydsl-apt:5.1.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
@@ -21,9 +28,6 @@ dependencies {
 
     implementation("net.dv8tion:JDA:5.6.1")
     implementation "org.apache.commons:commons-collections4:4.4" // for jda
-
-    implementation 'com.slack.api:slack-api-client:1.45.3'
-    implementation 'org.json:json:20240303' // for JSONObject
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 
@@ -42,4 +46,18 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
     workingDir = rootDir // TODO real hard trouble
+}
+
+def generatedDir = layout.buildDirectory.dir('generated/querydsl')
+
+sourceSets {
+    main.java.srcDirs += files(generatedDir)
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(generatedDir)
+}
+
+clean.doLast {
+    delete generatedDir
 }

--- a/estime-api/src/main/java/com/estime/common/BaseEntity.java
+++ b/estime-api/src/main/java/com/estime/common/BaseEntity.java
@@ -10,11 +10,13 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldNameConstants;
+import org.hibernate.annotations.SQLRestriction;
 
 @FieldNameConstants
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @MappedSuperclass
 @Getter
+@SQLRestriction("active = true")
 public abstract class BaseEntity {
 
     @Id

--- a/estime-api/src/main/java/com/estime/common/config/QueryDslConfig.java
+++ b/estime-api/src/main/java/com/estime/common/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.estime.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/estime-api/src/main/java/com/estime/room/domain/platform/Platform.java
+++ b/estime-api/src/main/java/com/estime/room/domain/platform/Platform.java
@@ -13,6 +13,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.FieldNameConstants;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/estime-api/src/main/java/com/estime/room/infrastructure/RoomJpaRepository.java
+++ b/estime-api/src/main/java/com/estime/room/infrastructure/RoomJpaRepository.java
@@ -1,19 +1,7 @@
 package com.estime.room.infrastructure;
 
 import com.estime.room.domain.Room;
-import com.estime.room.domain.vo.RoomSession;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RoomJpaRepository extends JpaRepository<Room, Long> {
-
-    Optional<Room> findBySessionAndActiveTrue(RoomSession session);
-
-    Optional<Room> findByIdAndActiveTrue(Long id);
-
-    List<Room> findAllByIdGreaterThanAndActiveTrueOrderByIdAsc(Long id);
-
-    List<Room> findAllByDeadlineAfterAndActiveTrue(LocalDateTime deadline);
 }

--- a/estime-api/src/main/java/com/estime/room/infrastructure/RoomRepositoryImpl.java
+++ b/estime-api/src/main/java/com/estime/room/infrastructure/RoomRepositoryImpl.java
@@ -1,8 +1,10 @@
 package com.estime.room.infrastructure;
 
+import com.estime.room.domain.QRoom;
 import com.estime.room.domain.Room;
 import com.estime.room.domain.RoomRepository;
 import com.estime.room.domain.vo.RoomSession;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -14,6 +16,7 @@ import org.springframework.stereotype.Repository;
 public class RoomRepositoryImpl implements RoomRepository {
 
     private final RoomJpaRepository roomJpaRepository;
+    private final JPAQueryFactory queryFactory;
 
     @Override
     public Room save(final Room room) {
@@ -22,26 +25,54 @@ public class RoomRepositoryImpl implements RoomRepository {
 
     @Override
     public Optional<Room> findBySession(final RoomSession session) {
-        return roomJpaRepository.findBySessionAndActiveTrue(session);
+        final QRoom room = QRoom.room;
+
+        return Optional.ofNullable(
+                queryFactory.selectFrom(room)
+                        .where(room.session.eq(session))
+                        .fetchOne()
+        );
     }
 
     @Override
     public Optional<Long> findIdBySession(final RoomSession session) {
-        return findBySession(session).map(Room::getId);
+        final QRoom room = QRoom.room;
+
+        return Optional.ofNullable(
+                queryFactory.select(room.id)
+                        .from(room)
+                        .where(room.session.eq(session))
+                        .fetchOne()
+        );
     }
 
     @Override
     public Optional<Room> findById(final Long id) {
-        return roomJpaRepository.findByIdAndActiveTrue(id);
+        final QRoom room = QRoom.room;
+
+        return Optional.ofNullable(
+                queryFactory.selectFrom(room)
+                        .where(room.id.eq(id))
+                        .fetchOne()
+        );
     }
 
     @Override
     public List<Room> findAllByIdGreaterThanOrderByIdAsc(final Long id) {
-        return roomJpaRepository.findAllByIdGreaterThanAndActiveTrueOrderByIdAsc(id);
+        final QRoom room = QRoom.room;
+
+        return queryFactory.selectFrom(room)
+                .where(room.id.gt(id))
+                .orderBy(room.id.asc())
+                .fetch();
     }
 
     @Override
     public List<Room> findAllByDeadlineAfter(final LocalDateTime criterion) {
-        return roomJpaRepository.findAllByDeadlineAfterAndActiveTrue(criterion);
+        final QRoom room = QRoom.room;
+
+        return queryFactory.selectFrom(room)
+                .where(room.deadline.after(criterion))
+                .fetch();
     }
 }

--- a/estime-api/src/main/java/com/estime/room/infrastructure/participant/ParticipantJpaRepository.java
+++ b/estime-api/src/main/java/com/estime/room/infrastructure/participant/ParticipantJpaRepository.java
@@ -1,19 +1,7 @@
 package com.estime.room.infrastructure.participant;
 
 import com.estime.room.domain.participant.Participant;
-import com.estime.room.domain.participant.vo.ParticipantName;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ParticipantJpaRepository extends JpaRepository<Participant, Long> {
-
-    Optional<Participant> findByRoomIdAndNameAndActiveTrue(Long roomId, ParticipantName name);
-
-    boolean existsByRoomIdAndNameAndActiveTrue(Long roomId, ParticipantName name);
-
-    List<Participant> findAllByRoomIdAndActiveTrue(Long roomId);
-
-    List<Participant> findByIdInAndActiveTrue(Collection<Long> ids);
 }

--- a/estime-api/src/main/java/com/estime/room/infrastructure/participant/ParticipantRepositoryImpl.java
+++ b/estime-api/src/main/java/com/estime/room/infrastructure/participant/ParticipantRepositoryImpl.java
@@ -1,9 +1,10 @@
 package com.estime.room.infrastructure.participant;
 
-import com.estime.common.BaseEntity;
 import com.estime.room.domain.participant.Participant;
 import com.estime.room.domain.participant.ParticipantRepository;
+import com.estime.room.domain.participant.QParticipant;
 import com.estime.room.domain.participant.vo.ParticipantName;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Repository;
 public class ParticipantRepositoryImpl implements ParticipantRepository {
 
     private final ParticipantJpaRepository jpaRepository;
+    private final JPAQueryFactory queryFactory;
 
     @Override
     public Participant save(final Participant participant) {
@@ -23,24 +25,43 @@ public class ParticipantRepositoryImpl implements ParticipantRepository {
 
     @Override
     public boolean existsByRoomIdAndName(final Long roomId, final ParticipantName name) {
-        return jpaRepository.existsByRoomIdAndNameAndActiveTrue(roomId, name);
+        final QParticipant participant = QParticipant.participant;
+
+        return queryFactory.selectFrom(participant)
+                .where(participant.roomId.eq(roomId)
+                        .and(participant.name.eq(name)))
+                .fetchOne() != null;
     }
 
     @Override
     public List<Long> findIdsByRoomId(final Long roomId) {
-        return jpaRepository.findAllByRoomIdAndActiveTrue(roomId).stream()
-                .map(BaseEntity::getId)
-                .toList();
+        final QParticipant participant = QParticipant.participant;
+
+        return queryFactory.select(participant.id)
+                .from(participant)
+                .where(participant.roomId.eq(roomId))
+                .fetch();
     }
 
     @Override
     public List<Participant> findAllByIdIn(final Set<Long> ids) {
-        return jpaRepository.findByIdInAndActiveTrue(ids);
+        final QParticipant participant = QParticipant.participant;
+
+        return queryFactory.selectFrom(participant)
+                .where(participant.id.in(ids))
+                .fetch();
     }
 
     @Override
     public Optional<Long> findIdByRoomIdAndName(final Long roomId, final ParticipantName name) {
-        return jpaRepository.findByRoomIdAndNameAndActiveTrue(roomId, name)
-                .map(Participant::getId);
+        final QParticipant participant = QParticipant.participant;
+
+        return Optional.ofNullable(
+                queryFactory.select(participant.id)
+                        .from(participant)
+                        .where(participant.roomId.eq(roomId)
+                                .and(participant.name.eq(name)))
+                        .fetchOne()
+        );
     }
 }

--- a/estime-api/src/main/java/com/estime/room/infrastructure/participant/vote/VoteJpaRepository.java
+++ b/estime-api/src/main/java/com/estime/room/infrastructure/participant/vote/VoteJpaRepository.java
@@ -2,12 +2,7 @@ package com.estime.room.infrastructure.participant.vote;
 
 import com.estime.room.domain.participant.vote.Vote;
 import com.estime.room.domain.participant.vote.VoteId;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface VoteJpaRepository extends JpaRepository<Vote, VoteId> {
-
-    List<Vote> findAllById_ParticipantIdIn(List<Long> participantIds);
-
-    List<Vote> findAllById_ParticipantId(Long participantId);
 }

--- a/estime-api/src/main/java/com/estime/room/infrastructure/platform/PlatformJpaRepository.java
+++ b/estime-api/src/main/java/com/estime/room/infrastructure/platform/PlatformJpaRepository.java
@@ -1,10 +1,7 @@
 package com.estime.room.infrastructure.platform;
 
 import com.estime.room.domain.platform.Platform;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PlatformJpaRepository extends JpaRepository<Platform, Long> {
-
-    Optional<Platform> findByRoomIdAndActiveTrue(Long roomId);
 }

--- a/estime-api/src/main/java/com/estime/room/infrastructure/platform/PlatformRepositoryImpl.java
+++ b/estime-api/src/main/java/com/estime/room/infrastructure/platform/PlatformRepositoryImpl.java
@@ -2,6 +2,8 @@ package com.estime.room.infrastructure.platform;
 
 import com.estime.room.domain.platform.Platform;
 import com.estime.room.domain.platform.PlatformRepository;
+import com.estime.room.domain.platform.QPlatform;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -11,6 +13,7 @@ import org.springframework.stereotype.Repository;
 public class PlatformRepositoryImpl implements PlatformRepository {
 
     private final PlatformJpaRepository jpaRepository;
+    private final JPAQueryFactory queryFactory;
 
     @Override
     public Platform save(final Platform platform) {
@@ -19,6 +22,12 @@ public class PlatformRepositoryImpl implements PlatformRepository {
 
     @Override
     public Optional<Platform> findByRoomId(final Long roomId) {
-        return jpaRepository.findByRoomIdAndActiveTrue(roomId);
+        final QPlatform platform = QPlatform.platform;
+
+        return Optional.ofNullable(
+                queryFactory.selectFrom(platform)
+                        .where(platform.roomId.eq(roomId))
+                        .fetchOne()
+        );
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #533 

## 📝 작업 내용

- Repository의 모든 RUD(Read, Update, Delete) 로직을 `JPAQueryFactory`를 사용하여 QueryDSL로 재작성
- `save` 메서드는 기존 `JpaRepository`에 위임하는 방식 유지
- `BaseEntity`에 `@SQLRestriction("active = true")`를 적용하여 반복적인 `where(XXX.active.isTrue()) `조건 제거

## 💬 리뷰 요구사항

- `BaseEntity`에 `@SQLRestriction("active = true")`를 적용하면 `active=false`로 조회하기 위해서는 직접 SQL 쿼리문을 작성해야 합니다. 그래서 `XXXRepositoryImpl`에 `isActive`를 확인하는, 재사용이 가능한 메서드를 두는 방식도 고려해봤는데 `active=false`로 조회하는 경우가 없어 현재 방식을 선택했습니다. 공통적인 필터링 처리에 대한 의견 부탁드립니다.

``` java
// 재사용 메서드 예시
private BooleanExpression isActive() {
    return participant.active.isTrue();
}
```