### PR TITLE
방 전체 투표 현황 조회 기능 참가자 리스트 추가

### DIFF
--- a/estime-api/src/main/java/com/estime/room/application/dto/output/DateTimeSlotStatisticOutput.java
+++ b/estime-api/src/main/java/com/estime/room/application/dto/output/DateTimeSlotStatisticOutput.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 public record DateTimeSlotStatisticOutput(
         int participantCount,
+        List<ParticipantName> participants,
         List<DateTimeParticipantsOutput> statistic
 ) {
 

--- a/estime-api/src/main/java/com/estime/room/application/service/RoomApplicationService.java
+++ b/estime-api/src/main/java/com/estime/room/application/service/RoomApplicationService.java
@@ -18,8 +18,8 @@ import com.estime.room.application.dto.output.RoomCreateOutput;
 import com.estime.room.application.dto.output.RoomOutput;
 import com.estime.room.domain.Room;
 import com.estime.room.domain.RoomRepository;
-import com.estime.room.domain.participant.Participant;
 import com.estime.room.domain.participant.ParticipantRepository;
+import com.estime.room.domain.participant.Participants;
 import com.estime.room.domain.participant.vo.ParticipantName;
 import com.estime.room.domain.participant.vote.VoteRepository;
 import com.estime.room.domain.participant.vote.Votes;
@@ -103,11 +103,14 @@ public class RoomApplicationService {
                 .flatMap(Collection::stream)
                 .collect(Collectors.toSet());
 
-        final Map<Long, ParticipantName> idToName = participantRepository.findAllByIdIn(participantsIds).stream()
-                .collect(Collectors.toMap(Participant::getId, Participant::getName));
+        // TODO: participantRepository 에서 Participants를 return 하도록 변경 논의 필요
+        final Participants participants = Participants.from(participantRepository.findAllByIdIn(participantsIds));
+
+        final Map<Long, ParticipantName> idToName = participants.getIdToName();
 
         return new DateTimeSlotStatisticOutput(
-                participantIds.size(),
+                participants.getSize(),
+                participants.getAllNames(),
                 dateTimeSlotParticipants.keySet().stream()
                         .map(dateTimeSlot ->
                                 new DateTimeParticipantsOutput(
@@ -116,7 +119,6 @@ public class RoomApplicationService {
                                                 .map(idToName::get)
                                                 .toList())
                         ).toList());
-
     }
 
     @Transactional(readOnly = true)

--- a/estime-api/src/main/java/com/estime/room/domain/participant/Participant.java
+++ b/estime-api/src/main/java/com/estime/room/domain/participant/Participant.java
@@ -37,8 +37,28 @@ public class Participant extends BaseEntity {
         return new Participant(roomId, name);
     }
 
+    static Participant withId(
+            final Long id,
+            final Long roomId,
+            final ParticipantName name
+    ) {
+        validateNull(id, roomId, name);
+        final Participant participant = new Participant(roomId, name);
+        participant.id = id;
+        return participant;
+    }
+
+
     private static void validateNull(final Long roomId, final ParticipantName name) {
         Validator.builder()
+                .add(Fields.roomId, roomId)
+                .add(Fields.name, name)
+                .validateNull();
+    }
+
+    private static void validateNull(final Long id, final Long roomId, final ParticipantName name) {
+        Validator.builder()
+                .add(BaseEntity.Fields.id, id)
                 .add(Fields.roomId, roomId)
                 .add(Fields.name, name)
                 .validateNull();

--- a/estime-api/src/main/java/com/estime/room/domain/participant/Participant.java
+++ b/estime-api/src/main/java/com/estime/room/domain/participant/Participant.java
@@ -37,28 +37,8 @@ public class Participant extends BaseEntity {
         return new Participant(roomId, name);
     }
 
-    static Participant withId(
-            final Long id,
-            final Long roomId,
-            final ParticipantName name
-    ) {
-        validateNull(id, roomId, name);
-        final Participant participant = new Participant(roomId, name);
-        participant.id = id;
-        return participant;
-    }
-
-
     private static void validateNull(final Long roomId, final ParticipantName name) {
         Validator.builder()
-                .add(Fields.roomId, roomId)
-                .add(Fields.name, name)
-                .validateNull();
-    }
-
-    private static void validateNull(final Long id, final Long roomId, final ParticipantName name) {
-        Validator.builder()
-                .add(BaseEntity.Fields.id, id)
                 .add(Fields.roomId, roomId)
                 .add(Fields.name, name)
                 .validateNull();

--- a/estime-api/src/main/java/com/estime/room/domain/participant/Participants.java
+++ b/estime-api/src/main/java/com/estime/room/domain/participant/Participants.java
@@ -25,6 +25,10 @@ public class Participants {
                 .validateNull();
     }
 
+    public List<Participant> getValues() {
+        return List.copyOf(values);
+    }
+
     public int getSize() {
         return values.size();
     }

--- a/estime-api/src/main/java/com/estime/room/domain/participant/Participants.java
+++ b/estime-api/src/main/java/com/estime/room/domain/participant/Participants.java
@@ -8,7 +8,7 @@ import java.util.stream.Collectors;
 
 public class Participants {
 
-    List<Participant> values;
+    private final List<Participant> values;
 
     private Participants(final List<Participant> values) {
         this.values = values;
@@ -16,7 +16,7 @@ public class Participants {
 
     public static Participants from(final List<Participant> participants) {
         validateNull(participants);
-        return new Participants(List.copyOf(participants));
+        return new Participants(java.util.List.copyOf(participants));
     }
 
     private static void validateNull(final List<Participant> participants) {

--- a/estime-api/src/main/java/com/estime/room/domain/participant/Participants.java
+++ b/estime-api/src/main/java/com/estime/room/domain/participant/Participants.java
@@ -1,0 +1,42 @@
+package com.estime.room.domain.participant;
+
+import com.estime.common.util.Validator;
+import com.estime.room.domain.participant.vo.ParticipantName;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class Participants {
+
+    List<Participant> values;
+
+    private Participants(final List<Participant> values) {
+        this.values = values;
+    }
+
+    public static Participants from(final List<Participant> participants) {
+        validateNull(participants);
+        return new Participants(List.copyOf(participants));
+    }
+
+    private static void validateNull(final List<Participant> participants) {
+        Validator.builder()
+                .add("participants", participants)
+                .validateNull();
+    }
+
+    public int getSize() {
+        return values.size();
+    }
+
+    public List<ParticipantName> getAllNames() {
+        return values.stream()
+                .map(Participant::getName)
+                .toList();
+    }
+
+    public Map<Long, ParticipantName> getIdToName() {
+        return values.stream()
+                .collect(Collectors.toMap(Participant::getId, Participant::getName));
+    }
+}

--- a/estime-api/src/main/java/com/estime/room/presentation/dto/response/DateTimeSlotStatisticResponse.java
+++ b/estime-api/src/main/java/com/estime/room/presentation/dto/response/DateTimeSlotStatisticResponse.java
@@ -9,14 +9,21 @@ import java.util.Comparator;
 import java.util.List;
 
 public record DateTimeSlotStatisticResponse(
-        @Schema(example = "5")
+        @Schema(example = "4")
         int participantCount,
+
+        @Schema(example = "[\"강산\", \"제프리\", \"플린트\", \"리버\"]")
+        List<String> participants,
         List<DateTimeSlotVotesResponse> statistic
 ) {
 
     public static DateTimeSlotStatisticResponse from(final DateTimeSlotStatisticOutput output) {
         return new DateTimeSlotStatisticResponse(
                 output.participantCount(),
+                output.participants()
+                        .stream()
+                        .map(ParticipantName::getValue)
+                        .toList(),
                 output.statistic()
                         .stream()
                         .map(each -> {

--- a/estime-api/src/test/java/com/estime/room/domain/participant/ParticipantsTest.java
+++ b/estime-api/src/test/java/com/estime/room/domain/participant/ParticipantsTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 class ParticipantsTest {
 
@@ -81,10 +82,10 @@ class ParticipantsTest {
     @Test
     void getIdToName() {
         // given
-        ParticipantName name1 = ParticipantName.from("test1");
-        ParticipantName name2 = ParticipantName.from("test2");
-        Participant participant1 = Participant.withId(101L, 1L, name1);
-        Participant participant2 = Participant.withId(102L, 1L, name2);
+        String name1 = "test1";
+        String name2 = "test2";
+        Participant participant1 = createParticipant(101L, 1L, name1);
+        Participant participant2 = createParticipant(102L, 1L, name2);
         Participants participants = Participants.from(List.of(participant1, participant2));
 
         // when
@@ -93,8 +94,14 @@ class ParticipantsTest {
         // then
         assertSoftly(softly -> {
             softly.assertThat(map).hasSize(2);
-            softly.assertThat(map.get(101L)).isEqualTo(name1);
-            softly.assertThat(map.get(102L)).isEqualTo(name2);
+            softly.assertThat(map.get(101L).getValue()).isEqualTo(name1);
+            softly.assertThat(map.get(102L).getValue()).isEqualTo(name2);
         });
+    }
+
+    private Participant createParticipant(Long id, Long roomId, String name) {
+        Participant participant = Participant.withoutId(roomId, ParticipantName.from(name));
+        ReflectionTestUtils.setField(participant, "id", id);
+        return participant;
     }
 }

--- a/estime-api/src/test/java/com/estime/room/domain/participant/ParticipantsTest.java
+++ b/estime-api/src/test/java/com/estime/room/domain/participant/ParticipantsTest.java
@@ -1,0 +1,100 @@
+package com.estime.room.domain.participant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import com.estime.common.exception.domain.NullNotAllowedException;
+import com.estime.room.domain.participant.vo.ParticipantName;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ParticipantsTest {
+
+    @Test
+    @DisplayName("정적 팩토리 메소드 from으로 Participants를 생성한다.")
+    void from() {
+        //given
+        Participant participant1 = Participant.withoutId(1L, ParticipantName.from("test1"));
+        Participant participant2 = Participant.withoutId(1L, ParticipantName.from("test2"));
+        List<Participant> participantList = List.of(participant1, participant2);
+
+        //when
+        Participants participants = Participants.from(participantList);
+
+        //then
+        assertSoftly(softly -> {
+            softly.assertThat(participants.getValues()).hasSize(2);
+            softly.assertThat(participants.getValues()).contains(participant1, participant2);
+        });
+    }
+
+    @DisplayName("from 메소드에 null을 전달하면 예외가 발생한다.")
+    @Test
+    void from_withNull() {
+        // given
+        final List<Participant> nullList = null;
+
+        // when & then
+        assertThatThrownBy(() -> Participants.from(nullList))
+                .isInstanceOf(NullNotAllowedException.class)
+                .hasMessageContaining("cannot be null");
+    }
+
+    @DisplayName("getSize 메소드가 요소 수를 반환한다.")
+    @Test
+    void getSize() {
+        // given
+        ParticipantName name1 = ParticipantName.from("test1");
+        ParticipantName name2 = ParticipantName.from("test2");
+        Participant participant1 = Participant.withoutId(1L, name1);
+        Participant participant2 = Participant.withoutId(1L, name2);
+        Participants participants = Participants.from(List.of(participant1, participant2));
+
+        // when & then
+        assertThat(participants.getSize()).isEqualTo(2);
+    }
+
+    @DisplayName("getAllNames 메소드가 모든 participant 이름을 반환한다.")
+    @Test
+    void getAllNames() {
+        // given
+        ParticipantName name1 = ParticipantName.from("test1");
+        ParticipantName name2 = ParticipantName.from("test2");
+        Participant participant1 = Participant.withoutId(1L, name1);
+        Participant participant2 = Participant.withoutId(1L, name2);
+        Participants participants = Participants.from(List.of(participant1, participant2));
+
+        // when
+        List<ParticipantName> names = participants.getAllNames();
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(names).hasSize(2);
+            softly.assertThat(names).containsExactly(name1, name2);
+        });
+    }
+
+    @DisplayName("getIdToName 메소드가 ID와 이름의 매핑을 반환한다.")
+    @Test
+    void getIdToName() {
+        // given
+        ParticipantName name1 = ParticipantName.from("test1");
+        ParticipantName name2 = ParticipantName.from("test2");
+        Participant participant1 = Participant.withId(101L, 1L, name1);
+        Participant participant2 = Participant.withId(102L, 1L, name2);
+        Participants participants = Participants.from(List.of(participant1, participant2));
+
+        // when
+        Map<Long, ParticipantName> map = participants.getIdToName();
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(map).hasSize(2);
+            softly.assertThat(map.get(101L)).isEqualTo(name1);
+            softly.assertThat(map.get(102L)).isEqualTo(name2);
+        });
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #535 

## 📝 작업 내용

방 전체 투표 현황 조회 기능에 참가자 리스트를 추가합니다. 기존 참가자 수 payload는 추후 프론트 팀원과 협의 후에 제거 여부를 결정할 예정입니다.

<img width="2004" height="1092" alt="image" src="https://github.com/user-attachments/assets/8957f405-8661-4f6a-b169-e4816efe91a4" />

## 💬 리뷰 요구사항
이번에 "전체 참가자명 찾기" 기능과 "id - 참가자명 map 생성" 기능이 동일한 List<Participants>를 사용하게 되어 `Participants` 일급 컬렉션을 추가했습니다! 

`participantRepository#findAllByIdIn`에서 `Participants`를 리턴하는 구조 리팩터링은 현재 진행 중인 QueryDSL 리팩터링이 완료된 후에 진행하는 것이 병합 문제가 덜 발생할 것 같아 지금 반영하지는 않았습니다.

테스트 관련해서 `idToName`을 위해 id를 설정하는 메서드가 필요하게 되었는데, id를 명시적으로 설정하는 경우는 지금 비즈니스 로직에서는 없다고 판단되서 `withId` 메서드를 `package-default`로 설정해 다른 패키지에서 사용하지 못하게 막는 방법이 유효할지 의견을 듣고 싶습니다. 

추가적으로 일급 컬렉션의 구조, 변수/메서드명, response payload 명이 적절한지 확인해주시면 감사하겠습니다!