### PR TITLE
추천 시간 조회 API 추가

### DIFF
--- a/estime-api/src/main/java/com/estime/room/application/dto/output/DateTimeSlotRecommendOutput.java
+++ b/estime-api/src/main/java/com/estime/room/application/dto/output/DateTimeSlotRecommendOutput.java
@@ -1,0 +1,16 @@
+package com.estime.room.application.dto.output;
+
+import com.estime.room.domain.participant.vo.ParticipantName;
+import com.estime.room.domain.slot.vo.DateTimeSlot;
+import java.util.List;
+
+public record DateTimeSlotRecommendOutput(
+        List<DateTimeRecommendsOutput> recommends
+) {
+
+    public record DateTimeRecommendsOutput(
+            DateTimeSlot dateTimeSlot,
+            List<ParticipantName> participantNames
+    ) {
+    }
+}

--- a/estime-api/src/main/java/com/estime/room/presentation/RoomController.java
+++ b/estime-api/src/main/java/com/estime/room/presentation/RoomController.java
@@ -4,6 +4,7 @@ import com.estime.common.CustomApiResponse;
 import com.estime.room.application.dto.input.RoomSessionInput;
 import com.estime.room.application.dto.input.VotesFindInput;
 import com.estime.room.application.dto.input.VotesOutput;
+import com.estime.room.application.dto.output.DateTimeSlotRecommendOutput;
 import com.estime.room.application.dto.output.DateTimeSlotStatisticOutput;
 import com.estime.room.application.dto.output.ParticipantCheckOutput;
 import com.estime.room.application.dto.output.RoomOutput;
@@ -13,6 +14,7 @@ import com.estime.room.presentation.dto.request.ParticipantCreateRequest;
 import com.estime.room.presentation.dto.request.ParticipantVotesUpdateRequest;
 import com.estime.room.presentation.dto.request.RoomCreateRequest;
 import com.estime.room.presentation.dto.response.ConnectedRoomCreateResponse;
+import com.estime.room.presentation.dto.response.DateTimeSlotRecommendResponse;
 import com.estime.room.presentation.dto.response.DateTimeSlotStatisticResponse;
 import com.estime.room.presentation.dto.response.ParticipantCheckResponse;
 import com.estime.room.presentation.dto.response.ParticipantVotesResponse;
@@ -62,6 +64,15 @@ public class RoomController implements RoomControllerSpecification {
         final DateTimeSlotStatisticOutput output = roomApplicationService.calculateVoteStatistic(
                 RoomSessionInput.from(roomSession));
         return CustomApiResponse.ok(DateTimeSlotStatisticResponse.from(output));
+    }
+
+    @Override
+    public CustomApiResponse<DateTimeSlotRecommendResponse> getDateTimeSlotRecommendBySession(
+            @PathVariable("session") final Tsid roomSession
+    ) {
+        final DateTimeSlotRecommendOutput output = roomApplicationService.calculateRecommend(
+                RoomSessionInput.from(roomSession));
+        return CustomApiResponse.ok(DateTimeSlotRecommendResponse.from(output));
     }
 
     @Override

--- a/estime-api/src/main/java/com/estime/room/presentation/RoomControllerSpecification.java
+++ b/estime-api/src/main/java/com/estime/room/presentation/RoomControllerSpecification.java
@@ -6,6 +6,7 @@ import com.estime.room.presentation.dto.request.ParticipantCreateRequest;
 import com.estime.room.presentation.dto.request.ParticipantVotesUpdateRequest;
 import com.estime.room.presentation.dto.request.RoomCreateRequest;
 import com.estime.room.presentation.dto.response.ConnectedRoomCreateResponse;
+import com.estime.room.presentation.dto.response.DateTimeSlotRecommendResponse;
 import com.estime.room.presentation.dto.response.DateTimeSlotStatisticResponse;
 import com.estime.room.presentation.dto.response.ParticipantCheckResponse;
 import com.estime.room.presentation.dto.response.ParticipantVotesResponse;
@@ -48,6 +49,12 @@ public interface RoomControllerSpecification {
     @Operation(summary = "일시 기준, 참여자 투표 통계 조회")
     @GetMapping("/{session}/statistics/date-time-slots")
     CustomApiResponse<DateTimeSlotStatisticResponse> getDateTimeSlotStatisticBySession(
+            @PathVariable("session") Tsid roomSession
+    );
+
+    @Operation(summary = "일시 기준, 참여자 투표 순위(Top 3) 조회")
+    @GetMapping("/{session}/recommendations/date-time-slots")
+    CustomApiResponse<DateTimeSlotRecommendResponse> getDateTimeSlotRecommendBySession(
             @PathVariable("session") Tsid roomSession
     );
 

--- a/estime-api/src/main/java/com/estime/room/presentation/dto/response/DateTimeSlotRecommendResponse.java
+++ b/estime-api/src/main/java/com/estime/room/presentation/dto/response/DateTimeSlotRecommendResponse.java
@@ -1,0 +1,29 @@
+package com.estime.room.presentation.dto.response;
+
+import com.estime.room.application.dto.output.DateTimeSlotRecommendOutput;
+import com.estime.room.domain.participant.vo.ParticipantName;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record DateTimeSlotRecommendResponse(
+        List<DateTimeSlotVotesResponse> recommends
+) {
+
+    public static DateTimeSlotRecommendResponse from(final DateTimeSlotRecommendOutput output) {
+        return new DateTimeSlotRecommendResponse(
+                output.recommends()
+                        .stream()
+                        .map(each -> new DateTimeSlotVotesResponse(
+                                each.dateTimeSlot().getStartAt(),
+                                each.participantNames().stream().map(ParticipantName::getValue).toList()
+                        ))
+                        .toList()
+        );
+    }
+
+    private record DateTimeSlotVotesResponse(
+            LocalDateTime dateTimeSlot,
+            List<String> participantNames
+    ) {
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #537 

## 📝 작업 내용

투표 수 기반 추천 시간 조회 api를 추가합니다. 최대 3개의 추천 시간대를 조회합니다.

<img width="2016" height="1233" alt="image" src="https://github.com/user-attachments/assets/ea8e4c58-1ce0-47a2-8aad-6d95811589bb" />

### 정렬 기준

- 1순위: 투표수 내림차순
- 2순위: 날짜 오름차순

## 💬 리뷰 요구사항
api 경로, dto, 메서드 명 등 이름이 적절한지, 추천 개수가 적절한지 확인해주시면 감사하겠습니다!