### PR TITLE
Broken Pipe 에러 로그 무시

### DIFF
--- a/estime-api/src/main/java/com/estime/common/sse/application/SseSender.java
+++ b/estime-api/src/main/java/com/estime/common/sse/application/SseSender.java
@@ -29,9 +29,9 @@ public class SseSender {
                                 .data(SseResponse.from("ok"))
                 );
             } catch (final IOException e) {
-                log.debug("Failed to send SSE message, connection likely closed for roomSession {}: {}", roomSession,
-                        e.getMessage());
-                emitter.completeWithError(e);
+                log.debug("Failed to send SSE message, connection likely closed for roomSession {}: {}",
+                        roomSession, e.getMessage());
+                emitter.complete();
             }
         }
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #542 

## 📝 작업 내용
sseEmitter에서 IOException(broken pipe)가 발생하면 completeWithError가 아닌 complete로 예외 무시

## 💬 리뷰 요구사항
