### PR TITLE
hotfix: og:image name 속성 변경 (property로)

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -16,6 +16,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://estime.today" />
     <meta property="og:site_name" content="아인슈타임" />
+    <meta property="og:image" content="<%= DOMAIN_URL %>/thumbnail.jpg" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -70,8 +70,8 @@ export default {
     new HtmlWebpackPlugin({
       template: './public/index.html',
       favicon: './src/assets/images/logo.svg',
-      meta: {
-        'og:image': `${process.env.DOMAIN_URL}/thumbnail.jpg`,
+      templateParameters: {
+        DOMAIN_URL: process.env.DOMAIN_URL,
       },
     }),
     new ForkTsCheckerPlugin(),


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#604 

## 📝 작업 내용
**변경 배경**
- 카카오톡 공유시, og 이미지가 제대로 나오지 않음.
<img width="377" height="136" alt="스크린샷 2025-09-25 오후 9 56 12" src="https://github.com/user-attachments/assets/cf827721-2fb6-45b5-a4ec-090f118c9035" />

이미지를 보면 태그에 property로 들어가야하는데, name으로 들어가고 있습니다.

**주요 변경사항**
- [x] HtmlWebpackPlugin 설정 개선
- [x] meta 옵션 대신 templateParameters를 활용해 환경 변수(DOMAIN_URL)를 index.html에서 직접 참조 가능하도록 변경
- [x] index.html 수정
- [x] `<meta property="og:image" content="<%= DOMAIN_URL %>/thumbnail.jpg">` 형태로 절대 경로 적용



## 💬 리뷰 요구사항
