### PR TITLE
fix: 잘못된 폰트 문법 수정

### DIFF
--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -7,9 +7,16 @@ body {
     Pretendard,
     -apple-system,
     BlinkMacSystemFont,
+    system-ui,
+    Roboto,
+    'Helvetica Neue',
+    'Segoe UI',
     'Apple SD Gothic Neo',
     'Noto Sans KR',
     'Malgun Gothic',
+    'Apple Color Emoji',
+    'Segoe UI Emoji',
+    'Segoe UI Symbol',
     sans-serif;
   font-display: swap;
 }

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -1,24 +1,17 @@
 @import url('./reset.css');
+@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css');
 
-@font-face {
+body {
   font-family:
     'Pretendard Variable',
     Pretendard,
     -apple-system,
     BlinkMacSystemFont,
-    system-ui,
-    Roboto,
-    'Helvetica Neue',
-    'Segoe UI',
     'Apple SD Gothic Neo',
     'Noto Sans KR',
     'Malgun Gothic',
-    'Apple Color Emoji',
-    'Segoe UI Emoji',
-    'Segoe UI Symbol',
     sans-serif;
   font-display: swap;
-  src: url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css');
 }
 
 :root {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
-closes #606 

## 📝 작업 내용
잘못된 css 문법으로 폰트가 누락되는 문제를 수정했습니다. (fallback 잘못 아님)

before:
<img width="1898" height="1800" alt="image" src="https://github.com/user-attachments/assets/eb45bb83-dfa3-48a1-924d-cd1d47558dfd" />


after: 
<img width="1890" height="1708" alt="CleanShot 2025-09-25 at 23 17 09@2x" src="https://github.com/user-attachments/assets/ba1a4481-711b-4822-a135-e621f800d432" />

## 💬 리뷰 요구사항

사죄의 의미로 내일 아침에 와서 푸시업 5개 하겠습니다!
