### PR TITLE
로컬 환경에서의 CORS 오류 해결 및 클라이언트 Origin URL 설정 구조 개선 

### DIFF
--- a/.github/workflows/CD-dev.yml
+++ b/.github/workflows/CD-dev.yml
@@ -32,9 +32,7 @@ jobs:
       SPRING_DATASOURCE_USERNAME: root
       SPRING_DATASOURCE_PASSWORD: testpw
 
-      URL_ORIGIN_LOCAL: ${{ secrets.URL_ORIGIN_LOCAL }}
-      URL_ORIGIN_DEV: ${{ secrets.URL_ORIGIN_DEV }}
-      URL_ORIGIN_PROD: ${{ secrets.URL_ORIGIN_PROD }}
+      URL_ORIGIN_CLIENT: ${{ secrets.URL_ORIGIN_DEV }}
 
       DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
 

--- a/.github/workflows/CD-prod.yml
+++ b/.github/workflows/CD-prod.yml
@@ -32,9 +32,7 @@ jobs:
       SPRING_DATASOURCE_USERNAME: root
       SPRING_DATASOURCE_PASSWORD: testpw
 
-      URL_ORIGIN_LOCAL: ${{ secrets.URL_ORIGIN_LOCAL }}
-      URL_ORIGIN_DEV: ${{ secrets.URL_ORIGIN_DEV }}
-      URL_ORIGIN_PROD: ${{ secrets.URL_ORIGIN_PROD }}
+      URL_ORIGIN_CLIENT: ${{ secrets.URL_ORIGIN_PROD }}
 
       DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,9 +32,7 @@ jobs:
       SPRING_DATASOURCE_USERNAME: root
       SPRING_DATASOURCE_PASSWORD: testpw
 
-      URL_ORIGIN_LOCAL: ${{ secrets.URL_ORIGIN_LOCAL }}
-      URL_ORIGIN_DEV: ${{ secrets.URL_ORIGIN_DEV }}
-      URL_ORIGIN_PROD: ${{ secrets.URL_ORIGIN_PROD }}
+      URL_ORIGIN_CLIENT: ${{ secrets.URL_ORIGIN_LOCAL }}
 
       DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
 

--- a/estime-api/src/main/java/com/estime/common/config/ClientOriginProperties.java
+++ b/estime-api/src/main/java/com/estime/common/config/ClientOriginProperties.java
@@ -4,8 +4,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "url.origin")
 public record ClientOriginProperties(
-        String local,
-        String dev,
-        String prod
+        String client
 ) {
 }

--- a/estime-api/src/main/java/com/estime/common/config/WebConfig.java
+++ b/estime-api/src/main/java/com/estime/common/config/WebConfig.java
@@ -16,7 +16,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(final CorsRegistry registry) {
         registry.addMapping("/api/**")
-                .allowedOrigins(properties.local(), properties.dev(), properties.prod())
+                .allowedOrigins(properties.client())
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(false)

--- a/estime-api/src/main/java/com/estime/room/infrastructure/platform/PlatformShortcutBuilder.java
+++ b/estime-api/src/main/java/com/estime/room/infrastructure/platform/PlatformShortcutBuilder.java
@@ -11,10 +11,10 @@ import org.springframework.web.util.UriComponentsBuilder;
 @RequiredArgsConstructor
 public class PlatformShortcutBuilder {
 
-    private final ClientOriginProperties clientOriginProperties;
+    private final ClientOriginProperties properties;
 
     public String buildConnectedRoomCreateUrl(final PlatformType type, final String channelId) {
-        return UriComponentsBuilder.fromUriString(clientOriginProperties.prod())
+        return UriComponentsBuilder.fromUriString(properties.client())
                 .queryParam("platformType", type.name())
                 .queryParam("channelId", channelId)
                 .build()
@@ -22,7 +22,8 @@ public class PlatformShortcutBuilder {
     }
 
     public String buildConnectedRoomUrl(final RoomSession session) {
-        return UriComponentsBuilder.fromUriString(clientOriginProperties.prod() + "check")
+        return UriComponentsBuilder.fromUriString(properties.client())
+                .path("check")
                 .queryParam("id", session.toString())
                 .build()
                 .toUriString();

--- a/estime-api/src/main/resources/application-dev.yml
+++ b/estime-api/src/main/resources/application-dev.yml
@@ -19,6 +19,10 @@ spring:
   flyway:
     enabled: true
 
+url:
+  origin:
+    client: ${URL_ORIGIN_CLIENT:https://test.estime.com/}
+
 springdoc:
   swagger-ui:
     path: /docs

--- a/estime-api/src/main/resources/application-dev.yml
+++ b/estime-api/src/main/resources/application-dev.yml
@@ -21,7 +21,7 @@ spring:
 
 url:
   origin:
-    client: ${URL_ORIGIN_CLIENT:https://test.estime.com/}
+    client: ${URL_ORIGIN_CLIENT}
 
 springdoc:
   swagger-ui:

--- a/estime-api/src/main/resources/application-local.yml
+++ b/estime-api/src/main/resources/application-local.yml
@@ -21,7 +21,7 @@ spring:
 
 url:
   origin:
-    client: ${URL_ORIGIN_CLIENT:http://localhost:3000/}
+    client: ${URL_ORIGIN_CLIENT}
 
 springdoc:
   swagger-ui:

--- a/estime-api/src/main/resources/application-local.yml
+++ b/estime-api/src/main/resources/application-local.yml
@@ -19,6 +19,10 @@ spring:
   flyway:
     enabled: true
 
+url:
+  origin:
+    client: ${URL_ORIGIN_CLIENT:http://localhost:3000/}
+
 springdoc:
   swagger-ui:
     path: /docs

--- a/estime-api/src/main/resources/application-prod.yml
+++ b/estime-api/src/main/resources/application-prod.yml
@@ -15,6 +15,10 @@ spring:
   flyway:
     enabled: true
 
+url:
+  origin:
+    client: ${URL_ORIGIN_CLIENT:https://estime.com/}
+
 logging:
   discord:
     webhook-url: ${DISCORD_LOG_WEBHOOK_URL}

--- a/estime-api/src/main/resources/application-prod.yml
+++ b/estime-api/src/main/resources/application-prod.yml
@@ -17,7 +17,7 @@ spring:
 
 url:
   origin:
-    client: ${URL_ORIGIN_CLIENT:https://estime.com/}
+    client: ${URL_ORIGIN_CLIENT}
 
 logging:
   discord:


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #614 

## 📝 작업 내용

- 기존 클라이언트 Origin URL 설정 방식은 로컬 개발 환경에서 CORS 오류 해결
   - local, dev, prod로 나뉘어 있던 프로퍼티를 활성 프로필에 따라 동적으로 적용되는 url.origin.client 단일 프로퍼티로 통합
   - ClientOriginProperties 클래스를 새로운 설정 구조에 맞게 수정
   - PlatformShortcutBuilder가 현재 활성 프로필에 맞는 Origin URL을 사용하도록 수정
   - 활성 프로필에 따른 CI/CD 환경 변수 설정 수정

## 💬 리뷰 요구사항

- 백엔드 노션 공유사항에 업데이트한 .env 파일이 올바른 지 확인 부탁드립니다.
- .env.dev, .env.prod 파일이 올바른지 확인 받은 후 GitHub Secrets의 ENV_DEV와 ENV_PROD 설정을 업데이트하겠습니다.