### PR TITLE
refactor: createEventPage 리펙터

### DIFF
--- a/frontend/src/apis/transform/toCreateRoomInfo.ts
+++ b/frontend/src/apis/transform/toCreateRoomInfo.ts
@@ -1,4 +1,3 @@
-import { RoomInfo } from '@/pages/CreateEvent/types/roomInfo';
 import { CreateRoomRequestType } from '@/apis/room/type';
 import { TimeManager } from '@/shared/utils/common/TimeManager';
 import { CreateRoomInfoType } from '@/pages/CreateEvent/types/roomInfo';

--- a/frontend/src/apis/transform/toCreateRoomInfo.ts
+++ b/frontend/src/apis/transform/toCreateRoomInfo.ts
@@ -1,6 +1,7 @@
 import { RoomInfo } from '@/pages/CreateEvent/types/roomInfo';
-import { CreateRoomRequestType } from '../room/type';
+import { CreateRoomRequestType } from '@/apis/room/type';
 import { TimeManager } from '@/shared/utils/common/TimeManager';
+import { CreateRoomInfoType } from '@/pages/CreateEvent/types/roomInfo';
 
 /**
  * 클라이언트 상태(RoomInfo)를 서버 요청 형식(CreateRoomRequestType)으로 변환합니다.
@@ -8,9 +9,7 @@ import { TimeManager } from '@/shared/utils/common/TimeManager';
  * @param roomInfo - 클라이언트에서 관리하는 방 생성 정보
  * @returns 서버에 전송할 API 요청 페이로드 형식
  */
-export const toCreateRoomInfo = (
-  roomInfo: RoomInfo & { time: { startTime: string; endTime: string } }
-): CreateRoomRequestType => {
+export const toCreateRoomInfo = (roomInfo: CreateRoomInfoType): CreateRoomRequestType => {
   const { title, availableDateSlots, time, deadline } = roomInfo;
 
   return {

--- a/frontend/src/constants/initialRoomInfo.ts
+++ b/frontend/src/constants/initialRoomInfo.ts
@@ -1,9 +1,9 @@
-import { RoomInfo } from '@/pages/CreateEvent/types/roomInfo';
+import type { CreateRoomInfoType, RoomInfo } from '@/pages/CreateEvent/types/roomInfo';
 import { DateManager } from '@/shared/utils/common/DateManager';
 
 const { defaultTime, defaultDate } = DateManager.getDefaultDeadline();
 
-export const initialCreateRoomInfo: RoomInfo & { time: { startTime: string; endTime: string } } = {
+export const initialCreateRoomInfo: CreateRoomInfoType = {
   title: '',
   availableDateSlots: new Set(),
   time: {

--- a/frontend/src/pages/CreateEvent/CreateEventPage.tsx
+++ b/frontend/src/pages/CreateEvent/CreateEventPage.tsx
@@ -1,17 +1,20 @@
 import Flex from '@/shared/layout/Flex';
 import Wrapper from '@/shared/layout/Wrapper';
-import BasicSettings from '@/pages/CreateEvent/components/BasicSettings';
+
+import { useRef, useState } from 'react';
+import { useNavigate } from 'react-router';
+
+import { showToast } from '@/shared/store/toastStore';
 import CalendarSettings from '@/pages/CreateEvent/components/CalendarSettings';
 import Button from '@/shared/components/Button';
 import Text from '@/shared/components/Text';
-import { useNavigate } from 'react-router';
 import useCreateRoom from '@/pages/CreateEvent/hooks/useCreateRoom';
 import useShakeAnimation from '@/shared/hooks/common/useShakeAnimation';
-import { useRef, useState } from 'react';
 import Modal from '@/shared/components/Modal';
 import NotificationModal from '@/pages/CreateEvent/components/NotificationModal';
 import useEnterKeySubmit from '@/shared/hooks/common/useEnterKeySubmit';
-import { showToast } from '@/shared/store/toastStore';
+import BasicSettings from '@/pages/CreateEvent/components/BasicSettings';
+import { checkBasicReady, checkCalendarReady } from '@/pages/CreateEvent/utils/CreateRoomValidator';
 
 const CreateEventPage = () => {
   const [notificationModal, setNotificationModal] = useState(false);
@@ -21,22 +24,11 @@ const CreateEventPage = () => {
 
   const showValidation = useRef(false);
   const navigate = useNavigate();
-  const {
-    platformType,
-    title,
-    availableDateSlots,
-    time,
-    deadline,
-    notification,
-    isCalendarReady,
-    isBasicReady,
-    roomInfoSubmit,
-    isRoomSubmitLoading,
-  } = useCreateRoom();
+  const { platformType, notification, roomInfoSubmit, isRoomSubmitLoading } = useCreateRoom();
   const { shouldShake, handleShouldShake } = useShakeAnimation();
 
   const handleValidation = () => {
-    if (!isCalendarReady && !isBasicReady) {
+    if (!checkCalendarReady() && !checkBasicReady()) {
       showToast({
         type: 'warning',
         message: '날짜와 약속 정보를 입력해주세요.',
@@ -45,7 +37,7 @@ const CreateEventPage = () => {
       handleShouldShake();
       return false;
     }
-    if (!isCalendarReady) {
+    if (!checkCalendarReady()) {
       showToast({
         type: 'warning',
         message: '날짜를 선택해주세요.',
@@ -54,7 +46,7 @@ const CreateEventPage = () => {
       handleShouldShake();
       return false;
     }
-    if (!isBasicReady) {
+    if (!checkBasicReady()) {
       showToast({
         type: 'warning',
         message: '약속 정보를 입력해주세요.',
@@ -106,18 +98,14 @@ const CreateEventPage = () => {
       <Flex justify="space-between" gap="var(--gap-9)">
         <Flex.Item flex={1}>
           <CalendarSettings
-            availableDateSlots={availableDateSlots}
-            isValid={!showValidation.current || isCalendarReady}
+            isValid={!showValidation.current || checkCalendarReady()}
             shouldShake={shouldShake}
           />
         </Flex.Item>
         <Flex.Item flex={1}>
           <Flex direction="column" justify="space-between" gap="var(--gap-8)">
             <BasicSettings
-              title={title}
-              time={time}
-              deadline={deadline}
-              isValid={!showValidation.current || isBasicReady}
+              isValid={!showValidation.current || checkBasicReady()}
               shouldShake={shouldShake}
             />
             <Flex justify="flex-end">

--- a/frontend/src/pages/CreateEvent/Mobile/MobileCreateEventPage.tsx
+++ b/frontend/src/pages/CreateEvent/Mobile/MobileCreateEventPage.tsx
@@ -16,6 +16,7 @@ import useFunnelWithHistory from '@/shared/hooks/Funnel/useFunnelWithHistory';
 import Modal from '@/shared/components/Modal';
 import NotificationModal from '@/pages/CreateEvent/components/NotificationModal';
 import { showToast } from '@/shared/store/toastStore';
+import { checkBasicReady, checkCalendarReady } from '@/pages/CreateEvent/utils/CreateRoomValidator';
 
 const STEP = ['메인 화면', '캘린더 선택 화면', '제목 및 시간 선택 화면'] as const;
 
@@ -28,23 +29,12 @@ const MobileCreateEventPage = () => {
   const navigate = useNavigate();
   const theme = useTheme();
   const { Funnel, step, stepNext, stepPrev } = useFunnelWithHistory(STEP);
-  const {
-    platformType,
-    title,
-    availableDateSlots,
-    time,
-    deadline,
-    notification,
-    isCalendarReady,
-    isBasicReady,
-    roomInfoSubmit,
-    isRoomSubmitLoading,
-  } = useCreateRoom();
+  const { platformType, notification, roomInfoSubmit, isRoomSubmitLoading } = useCreateRoom();
   const { shouldShake, handleShouldShake } = useShakeAnimation();
 
   const handleNextStep = async (type: 'calendar' | 'rest') => {
     if (type === 'calendar') {
-      if (!isCalendarReady) {
+      if (!checkCalendarReady()) {
         showToast({ type: 'warning', message: '날짜를 선택해주세요.' });
         showValidation.current.calendar = true;
         handleShouldShake();
@@ -55,7 +45,7 @@ const MobileCreateEventPage = () => {
     }
 
     if (type === 'rest') {
-      if (!isBasicReady) {
+      if (!checkBasicReady()) {
         showToast({ type: 'warning', message: '약속 정보를 입력해주세요.' });
         showValidation.current.rest = true;
         handleShouldShake();
@@ -123,8 +113,7 @@ const MobileCreateEventPage = () => {
         <Funnel.Step name="캘린더 선택 화면">
           <Flex direction="column" justify="space-between" gap="var(--gap-8)">
             <CalendarSettings
-              availableDateSlots={availableDateSlots}
-              isValid={!showValidation.current.calendar || isCalendarReady}
+              isValid={!showValidation.current.calendar || checkCalendarReady()}
               shouldShake={shouldShake}
             />
 
@@ -157,12 +146,10 @@ const MobileCreateEventPage = () => {
         <Funnel.Step name="제목 및 시간 선택 화면">
           <Flex direction="column" justify="space-between" gap="var(--gap-8)">
             <BasicSettings
-              title={title}
-              time={time}
-              deadline={deadline}
-              isValid={!showValidation.current.rest || isBasicReady}
+              isValid={!showValidation.current.rest || checkBasicReady()}
               shouldShake={shouldShake}
             />
+
             <Flex justify="space-between" gap="var(--gap-4)">
               <Button
                 color="primary"

--- a/frontend/src/pages/CreateEvent/Mobile/MobileCreateEventPage.tsx
+++ b/frontend/src/pages/CreateEvent/Mobile/MobileCreateEventPage.tsx
@@ -2,88 +2,29 @@ import Flex from '@/shared/layout/Flex';
 import Wrapper from '@/shared/layout/Wrapper';
 import Button from '@/shared/components/Button';
 import Text from '@/shared/components/Text';
-import { useNavigate } from 'react-router';
-import useCreateRoom from '@/pages/CreateEvent/hooks/useCreateRoom';
-import useShakeAnimation from '@/shared/hooks/common/useShakeAnimation';
-import { useRef, useState } from 'react';
 import IEstimeLogo from '@/assets/icons/IEstimeLogo';
-import { useTheme } from '@emotion/react';
 import IEstimeIcon from '@/assets/icons/IEstimeIcon';
+import { useTheme } from '@emotion/react';
 import * as S from './MobileCreateEventPage.styled';
 import CalendarSettings from '@/pages/CreateEvent/components/CalendarSettings';
 import BasicSettings from '@/pages/CreateEvent/components/BasicSettings';
-import useFunnelWithHistory from '@/shared/hooks/Funnel/useFunnelWithHistory';
 import Modal from '@/shared/components/Modal';
 import NotificationModal from '@/pages/CreateEvent/components/NotificationModal';
-import { showToast } from '@/shared/store/toastStore';
-import { checkBasicReady, checkCalendarReady } from '@/pages/CreateEvent/utils/CreateRoomValidator';
-
-const STEP = ['메인 화면', '캘린더 선택 화면', '제목 및 시간 선택 화면'] as const;
+import useMobileCreateRoomController from '../hooks/useMobileCreateRoomController';
 
 const MobileCreateEventPage = () => {
-  const [notificationModal, setNotificationModal] = useState(false);
-  const showValidation = useRef({
-    calendar: false,
-    rest: false,
-  });
-  const navigate = useNavigate();
+  const {
+    notificationModal,
+    checkNotification,
+    isValid,
+    animation,
+    isRoomCreateLoading,
+    handler,
+    funnel,
+  } = useMobileCreateRoomController();
+
+  const { Funnel, step, stepNext, stepPrev } = funnel;
   const theme = useTheme();
-  const { Funnel, step, stepNext, stepPrev } = useFunnelWithHistory(STEP);
-  const { platformType, notification, roomInfoSubmit, isRoomSubmitLoading } = useCreateRoom();
-  const { shouldShake, handleShouldShake } = useShakeAnimation();
-
-  const handleNextStep = async (type: 'calendar' | 'rest') => {
-    if (type === 'calendar') {
-      if (!checkCalendarReady()) {
-        showToast({ type: 'warning', message: '날짜를 선택해주세요.' });
-        showValidation.current.calendar = true;
-        handleShouldShake();
-        return; // 유효하지 않으면 종료
-      }
-      stepNext();
-      return;
-    }
-
-    if (type === 'rest') {
-      if (!checkBasicReady()) {
-        showToast({ type: 'warning', message: '약속 정보를 입력해주세요.' });
-        showValidation.current.rest = true;
-        handleShouldShake();
-        return;
-      }
-      await handleCreateRoom(); // 최종 단계는 생성으로 종료
-      return;
-    }
-  };
-
-  const onSubmitSuccess = (session: string) => {
-    showToast({ type: 'success', message: '방 생성이 완료되었습니다.' });
-    navigate(`/check?id=${session}`, { replace: true });
-  };
-
-  //  실제 제출
-  const submitAndNavigate = async () => {
-    const session = await roomInfoSubmit();
-    if (session) onSubmitSuccess(session);
-  };
-
-  // 메인 버튼 핸들러
-  const handleCreateRoom = async () => {
-    // 디스코드 연동이면 모달 오픈 후 모달에서 최종 제출
-    if (platformType) {
-      setNotificationModal(true);
-      return;
-    }
-
-    // 일반 생성 플로우
-    await submitAndNavigate();
-  };
-
-  // 디스코드 핸들러
-  const handleDiscordCreateRoom = async () => {
-    await submitAndNavigate();
-    setNotificationModal(false);
-  };
 
   return (
     <Wrapper maxWidth={430} padding="var(--padding-6)" borderRadius="var(--radius-4)">
@@ -112,10 +53,7 @@ const MobileCreateEventPage = () => {
 
         <Funnel.Step name="캘린더 선택 화면">
           <Flex direction="column" justify="space-between" gap="var(--gap-8)">
-            <CalendarSettings
-              isValid={!showValidation.current.calendar || checkCalendarReady()}
-              shouldShake={shouldShake}
-            />
+            <CalendarSettings isValid={isValid.calendar} shouldShake={animation.shake} />
 
             <Flex justify="space-between" gap="var(--gap-4)">
               <Button
@@ -133,7 +71,7 @@ const MobileCreateEventPage = () => {
                 color="primary"
                 selected={true}
                 size="large"
-                onClick={() => handleNextStep('calendar')}
+                onClick={() => handler.nextStep('calendar')}
               >
                 <Text variant="button" color="background">
                   다음
@@ -145,10 +83,7 @@ const MobileCreateEventPage = () => {
 
         <Funnel.Step name="제목 및 시간 선택 화면">
           <Flex direction="column" justify="space-between" gap="var(--gap-8)">
-            <BasicSettings
-              isValid={!showValidation.current.rest || checkBasicReady()}
-              shouldShake={shouldShake}
-            />
+            <BasicSettings isValid={isValid.basic} shouldShake={animation.shake} />
 
             <Flex justify="space-between" gap="var(--gap-4)">
               <Button
@@ -166,12 +101,12 @@ const MobileCreateEventPage = () => {
                 color="primary"
                 selected={true}
                 size="large"
-                onClick={() => handleNextStep('rest')}
+                onClick={() => handler.nextStep('basic')}
                 data-ga-id="create-event-button"
-                disabled={isRoomSubmitLoading}
+                disabled={isRoomCreateLoading}
               >
                 <Text variant="button" color="background">
-                  {isRoomSubmitLoading ? '방 생성 중...' : '방 만들기'}
+                  {isRoomCreateLoading ? '방 생성 중...' : '방 만들기'}
                 </Text>
               </Button>
             </Flex>
@@ -179,11 +114,15 @@ const MobileCreateEventPage = () => {
         </Funnel.Step>
       </Funnel>
       <Modal
-        isOpen={notificationModal}
-        onClose={() => setNotificationModal(false)}
+        isOpen={notificationModal.isOpen}
+        onClose={() => notificationModal.setIsOpen(false)}
         position="center"
       >
-        <NotificationModal notification={notification} handleCreateRoom={handleDiscordCreateRoom} />
+        <NotificationModal
+          notification={checkNotification}
+          handleCreateRoom={handler.platformCreateRoom}
+          isRoomCreateLoading={isRoomCreateLoading}
+        />
       </Modal>
     </Wrapper>
   );

--- a/frontend/src/pages/CreateEvent/components/BasicSettings/BasicSettings.stories.tsx
+++ b/frontend/src/pages/CreateEvent/components/BasicSettings/BasicSettings.stories.tsx
@@ -1,8 +1,5 @@
 import type { Meta, StoryFn } from '@storybook/react-webpack5';
 import BasicSettings from '.';
-import { useState } from 'react';
-import type { Field } from '@/pages/CreateEvent/types/field';
-import { TimeManager } from '@/shared/utils/common/TimeManager';
 
 export default {
   title: 'Components/BasicSettings',
@@ -17,40 +14,8 @@ export default {
   },
 } as Meta<typeof BasicSettings>;
 
-const Template: StoryFn<{ isValid: boolean }> = (args) => {
-  const [title, setTitle] = useState('');
-  const titleField: Field<string> = {
-    value: title,
-    set: setTitle,
-  };
-
-  const [time, setTime] = useState({ startTime: '', endTime: '' });
-
-  const timeField: Field<{ startTime: string; endTime: string }> & { valid: boolean } = {
-    value: time,
-    set: setTime,
-    valid: TimeManager.isValidRange(time.startTime, time.endTime),
-  };
-
-  const [deadline, setdeadline] = useState<{ date: string; time: string }>({
-    date: '2025-07-23',
-    time: '16:00',
-  });
-
-  const deadlineField: Field<{ date: string; time: string }> = {
-    value: deadline,
-    set: setdeadline,
-  };
-
-  return (
-    <BasicSettings
-      title={titleField}
-      time={timeField}
-      deadline={deadlineField}
-      isValid={args.isValid}
-      shouldShake={true}
-    />
-  );
+const Template: StoryFn<{ isValid: boolean }> = () => {
+  return <BasicSettings isValid={true} shouldShake={false} />;
 };
 
 export const Default = Template.bind({});

--- a/frontend/src/pages/CreateEvent/components/BasicSettings/index.tsx
+++ b/frontend/src/pages/CreateEvent/components/BasicSettings/index.tsx
@@ -13,7 +13,7 @@ import {
   onChangeTime,
   onChangeTitle,
   useRoomSelector,
-} from '@/shared/store/createRoomStore';
+} from '@/pages/CreateEvent/store/createRoomStore';
 import { checkTimeRangeValid } from '@/pages/CreateEvent/utils/CreateRoomValidator';
 
 type BasicSettingsProps = {

--- a/frontend/src/pages/CreateEvent/components/BasicSettings/index.tsx
+++ b/frontend/src/pages/CreateEvent/components/BasicSettings/index.tsx
@@ -2,111 +2,137 @@ import Text from '@/shared/components/Text';
 import * as S from './BasicSettings.styled';
 import Input from '@/shared/components/Input';
 import useSelectTime from '@/pages/CreateEvent/hooks/useSelectTime';
-import { Field } from '@/pages/CreateEvent/types/field';
 import { useMemo } from 'react';
 import DatePicker from '@/shared/components/DatePicker';
 import Flex from '@/shared/layout/Flex';
 import useToggleState from '@/shared/hooks/common/useToggleState';
 import { TimeManager } from '@/shared/utils/common/TimeManager';
 import TimePicker from '@/shared/components/Timepicker';
+import {
+  onChangeDeadline,
+  onChangeTime,
+  onChangeTitle,
+  useRoomSelector,
+} from '@/shared/store/createRoomStore';
+import { checkTimeRangeValid } from '@/pages/CreateEvent/utils/CreateRoomValidator';
 
 type BasicSettingsProps = {
-  title: Field<string>;
-  time: Field<{ startTime: string; endTime: string }> & { valid: boolean };
-  deadline: Field<{ date: string; time: string }>;
   isValid: boolean;
   shouldShake: boolean;
 };
 
-const BasicSettings = ({ title, time, deadline, isValid, shouldShake }: BasicSettingsProps) => {
-  const { isOpen: isStartOpen, toggleOpen: toggleStartOpen } = useToggleState();
-  const { isOpen: isEndOpen, toggleOpen: toggleEndOpen } = useToggleState();
-  const { isOpen: isDeadLineOpen, toggleOpen: toggleDeadLineOpen } = useToggleState();
+const BasicSettings = ({ isValid, shouldShake }: BasicSettingsProps) => {
+  return (
+    <S.Container isValid={isValid} shouldShake={shouldShake}>
+      <TitleSettings />
+      <TimeSettings />
+      <DeadlineSettings />
+    </S.Container>
+  );
+};
 
-  const deadlineHourOptions = useMemo(() => {
-    return TimeManager.filterHourOptions(deadline.value);
-  }, [deadline.value]);
+export const TitleSettings = () => {
+  const title = useRoomSelector('title');
+  return (
+    <S.InfoWrapper>
+      <S.TextWrapper>
+        <Text variant="h3">제목</Text>
+        <Text variant="h4">참여자들에게 표시될 약속의 제목을 입력해주세요.</Text>
+      </S.TextWrapper>
+      <S.InputWrapper>
+        <Input
+          placeholder="예: 아인슈타임 정기 산악회"
+          value={title}
+          onChange={(e) => onChangeTitle(e.target.value)}
+          maxLength={20}
+        />
+      </S.InputWrapper>
+    </S.InfoWrapper>
+  );
+};
 
+export const TimeSettings = () => {
+  const time = useRoomSelector('time');
   const {
     timeRange,
     startHourOptions,
     endHourOptions,
     handleCustomStartClick,
     handleCustomEndClick,
-  } = useSelectTime({ timeRange: time.value, setTimeRange: time.set });
+  } = useSelectTime({ timeRange: time, setTimeRange: onChangeTime });
+
+  const { isOpen: isStartOpen, toggleOpen: toggleStartOpen } = useToggleState();
+  const { isOpen: isEndOpen, toggleOpen: toggleEndOpen } = useToggleState();
+
   return (
-    <S.Container isValid={isValid} shouldShake={shouldShake}>
-      <S.InfoWrapper>
-        <S.TextWrapper>
-          <Text variant="h3">제목</Text>
-          <Text variant="h4">참여자들에게 표시될 약속의 제목을 입력해주세요.</Text>
-        </S.TextWrapper>
-        <S.InputWrapper>
-          <Input
-            placeholder="예: 아인슈타임 정기 산악회"
-            value={title.value}
-            onChange={(e) => title.set(e.target.value)}
-            maxLength={20}
-          />
-        </S.InputWrapper>
-      </S.InfoWrapper>
-      <S.InfoWrapper>
-        <S.TextWrapper>
-          <Text variant="h3">시간 선택</Text>
-          <Text variant="h4">참여자가 선택할 수 있는 시간의 범위를 설정합니다.</Text>
-        </S.TextWrapper>
+    <S.InfoWrapper>
+      <S.TextWrapper>
+        <Text variant="h3">시간 선택</Text>
+        <Text variant="h4">참여자가 선택할 수 있는 시간의 범위를 설정합니다.</Text>
+      </S.TextWrapper>
 
-        <Flex direction="column" gap="var(--gap-2)">
-          <Flex direction="row" gap="var(--gap-4)">
-            <S.Label>
-              <Text variant="body">시작 시간</Text>
-              <TimePicker
-                selectedHour={timeRange.startTime}
-                selectHour={handleCustomStartClick}
-                toggleOpen={toggleStartOpen}
-                isOpen={isStartOpen}
-                hourOptions={startHourOptions}
-              />
-            </S.Label>
-            <S.Label>
-              <Text variant="body">종료 시간</Text>
-              <TimePicker
-                selectedHour={timeRange.endTime}
-                selectHour={handleCustomEndClick}
-                toggleOpen={toggleEndOpen}
-                isOpen={isEndOpen}
-                hourOptions={endHourOptions}
-              />
-            </S.Label>
-          </Flex>
+      <Flex direction="column" gap="var(--gap-2)">
+        <Flex direction="row" gap="var(--gap-4)">
+          <S.Label>
+            <Text variant="body">시작 시간</Text>
+            <TimePicker
+              selectedHour={timeRange.startTime}
+              selectHour={handleCustomStartClick}
+              toggleOpen={toggleStartOpen}
+              isOpen={isStartOpen}
+              hourOptions={startHourOptions}
+            />
+          </S.Label>
+          <S.Label>
+            <Text variant="body">종료 시간</Text>
+            <TimePicker
+              selectedHour={timeRange.endTime}
+              selectHour={handleCustomEndClick}
+              toggleOpen={toggleEndOpen}
+              isOpen={isEndOpen}
+              hourOptions={endHourOptions}
+            />
+          </S.Label>
+        </Flex>
 
-          {!time.valid && (
-            <Text variant="caption" color="red40">
-              종료 시간은 시작 시간보다 빠를 수 없습니다. 다시 선택해주세요.
-            </Text>
-          )}
-        </Flex>
-      </S.InfoWrapper>
-      <S.InfoWrapper>
-        <S.TextWrapper>
-          <Text variant="h3">투표 마감 기한</Text>
-          <Text variant="h4">참여자들이 응답할 수 있는 마감 기한을 설정합니다.</Text>
-        </S.TextWrapper>
-        <Flex gap="var(--gap-4)">
-          <DatePicker
-            value={deadline.value.date}
-            onChange={(e) => deadline.set({ date: e.target.value, time: deadline.value.time })}
-          />
-          <TimePicker
-            selectedHour={deadline.value.time}
-            selectHour={(hour: string) => deadline.set({ date: deadline.value.date, time: hour })}
-            toggleOpen={toggleDeadLineOpen}
-            isOpen={isDeadLineOpen}
-            hourOptions={deadlineHourOptions}
-          />
-        </Flex>
-      </S.InfoWrapper>
-    </S.Container>
+        {!checkTimeRangeValid() && (
+          <Text variant="caption" color="red40">
+            종료 시간은 시작 시간보다 빠를 수 없습니다. 다시 선택해주세요.
+          </Text>
+        )}
+      </Flex>
+    </S.InfoWrapper>
+  );
+};
+
+export const DeadlineSettings = () => {
+  const deadline = useRoomSelector('deadline');
+
+  const deadlineHourOptions = useMemo(() => {
+    return TimeManager.filterHourOptions(deadline);
+  }, [deadline]);
+  const { isOpen: isDeadLineOpen, toggleOpen: toggleDeadLineOpen } = useToggleState();
+
+  return (
+    <S.InfoWrapper>
+      <S.TextWrapper>
+        <Text variant="h3">투표 마감 기한</Text>
+        <Text variant="h4">참여자들이 응답할 수 있는 마감 기한을 설정합니다.</Text>
+      </S.TextWrapper>
+      <Flex gap="var(--gap-4)">
+        <DatePicker
+          value={deadline.date}
+          onChange={(e) => onChangeDeadline({ date: e.target.value, time: deadline.time })}
+        />
+        <TimePicker
+          selectedHour={deadline.time}
+          selectHour={(hour: string) => onChangeDeadline({ date: deadline.date, time: hour })}
+          toggleOpen={toggleDeadLineOpen}
+          isOpen={isDeadLineOpen}
+          hourOptions={deadlineHourOptions}
+        />
+      </Flex>
+    </S.InfoWrapper>
   );
 };
 

--- a/frontend/src/pages/CreateEvent/components/Calendar/index.tsx
+++ b/frontend/src/pages/CreateEvent/components/Calendar/index.tsx
@@ -2,32 +2,28 @@ import * as S from './Calendar.styled';
 import { weekdays } from '@/constants/calender';
 import { useCalender } from '@/pages/CreateEvent/hooks/Calendar/useCalender';
 
-import PageArrowButton from '../../../../shared/components/Button/PageArrowButton';
+import PageArrowButton from '@/shared/components/Button/PageArrowButton';
 import DayCell from './DayCell';
 import Text from '@/shared/components/Text';
 import IChevronLeft from '@/assets/icons/IChevronLeft';
 import IChevronRight from '@/assets/icons/IChevronRight';
-import Flex from '../../../../shared/layout/Flex';
+import Flex from '@/shared/layout/Flex';
 import { DateManager } from '@/shared/utils/common/DateManager';
-import { onChangeAvailableDateSlots, useRoomSelector } from '@/shared/store/createRoomStore';
-import { useDateSelection } from '../../hooks/Calendar/useDateSelection';
+import {
+  onChangeAvailableDateSlots,
+  useRoomSelector,
+} from '@/pages/CreateEvent/store/createRoomStore';
+import { useDateSelection } from '@/pages/CreateEvent/hooks/Calendar/useDateSelection';
 
 const Calender = () => {
   const today = new Date();
-  const { current, prevMonth, nextMonth, monthMatrix } = useCalender(today);
   const selectedDates = useRoomSelector('availableDateSlots');
-  const dateSelection = useDateSelection({
+  const { current, prevMonth, nextMonth, monthMatrix } = useCalender(today);
+  const { onMouseDown, onMouseEnter, onMouseLeave, onMouseUp } = useDateSelection({
     selectedDates,
     setSelectedDates: onChangeAvailableDateSlots,
     today,
   });
-  const mouseHandlers = {
-    onMouseDown: dateSelection.onMouseDown,
-    onMouseEnter: dateSelection.onMouseEnter,
-    onMouseUp: dateSelection.onMouseUp,
-    onMouseLeave: dateSelection.onMouseLeave,
-  };
-  const { onMouseDown, onMouseEnter, onMouseUp, onMouseLeave } = mouseHandlers;
 
   return (
     <S.Container>

--- a/frontend/src/pages/CreateEvent/components/Calendar/index.tsx
+++ b/frontend/src/pages/CreateEvent/components/Calendar/index.tsx
@@ -9,20 +9,24 @@ import IChevronLeft from '@/assets/icons/IChevronLeft';
 import IChevronRight from '@/assets/icons/IChevronRight';
 import Flex from '../../../../shared/layout/Flex';
 import { DateManager } from '@/shared/utils/common/DateManager';
+import { onChangeAvailableDateSlots, useRoomSelector } from '@/shared/store/createRoomStore';
+import { useDateSelection } from '../../hooks/Calendar/useDateSelection';
 
-interface CalenderProps {
-  today: Date;
-  selectedDates: Set<string>;
-  mouseHandlers: {
-    onMouseDown: (date: Date | null) => void;
-    onMouseEnter: (date: Date | null) => void;
-    onMouseUp: () => void;
-    onMouseLeave: () => void;
-  };
-}
-
-const Calender = ({ today, selectedDates, mouseHandlers }: CalenderProps) => {
+const Calender = () => {
+  const today = new Date();
   const { current, prevMonth, nextMonth, monthMatrix } = useCalender(today);
+  const selectedDates = useRoomSelector('availableDateSlots');
+  const dateSelection = useDateSelection({
+    selectedDates,
+    setSelectedDates: onChangeAvailableDateSlots,
+    today,
+  });
+  const mouseHandlers = {
+    onMouseDown: dateSelection.onMouseDown,
+    onMouseEnter: dateSelection.onMouseEnter,
+    onMouseUp: dateSelection.onMouseUp,
+    onMouseLeave: dateSelection.onMouseLeave,
+  };
   const { onMouseDown, onMouseEnter, onMouseUp, onMouseLeave } = mouseHandlers;
 
   return (

--- a/frontend/src/pages/CreateEvent/components/CalendarSettings/index.tsx
+++ b/frontend/src/pages/CreateEvent/components/CalendarSettings/index.tsx
@@ -1,40 +1,20 @@
-import Calender from '@/pages/CreateEvent/components/Calendar';
+import Calender from '../Calendar';
 import * as S from './CalendarSettings.styled';
-import { useDateSelection } from '@/pages/CreateEvent/hooks/Calendar/useDateSelection';
 import Text from '@/shared/components/Text';
-import type { Field } from '@/pages/CreateEvent/types/field';
 
 type CalendarSettingsProps = {
-  availableDateSlots: Field<Set<string>>;
   isValid: boolean;
   shouldShake: boolean;
 };
 
-const CalendarSettings = ({ availableDateSlots, isValid, shouldShake }: CalendarSettingsProps) => {
-  const today = new Date();
-  const dateSelection = useDateSelection({
-    selectedDates: availableDateSlots.value,
-    setSelectedDates: availableDateSlots.set,
-    today,
-  });
-  const mouseHandlers = {
-    onMouseDown: dateSelection.onMouseDown,
-    onMouseEnter: dateSelection.onMouseEnter,
-    onMouseUp: dateSelection.onMouseUp,
-    onMouseLeave: dateSelection.onMouseLeave,
-  };
-
+const CalendarSettings = ({ isValid, shouldShake }: CalendarSettingsProps) => {
   return (
     <S.Container isValid={isValid} shouldShake={shouldShake}>
       <S.TextWrapper>
         <Text variant="h3">날짜 선택</Text>
         <Text variant="h4">가능한 날짜를 드래그해서 선택해주세요!</Text>
       </S.TextWrapper>
-      <Calender
-        today={today}
-        selectedDates={availableDateSlots.value}
-        mouseHandlers={mouseHandlers}
-      />
+      <Calender />
     </S.Container>
   );
 };

--- a/frontend/src/pages/CreateEvent/components/NotificationModal/index.tsx
+++ b/frontend/src/pages/CreateEvent/components/NotificationModal/index.tsx
@@ -1,9 +1,9 @@
-import Button from '../../../../shared/components/Button';
-import Check from '../../../../shared/components/Check';
-import Flex from '../../../../shared/layout/Flex';
-import Wrapper from '../../../../shared/layout/Wrapper';
-import Modal from '../../../../shared/components/Modal';
-import Text from '../../../../shared/components/Text';
+import Button from '@/shared/components/Button';
+import Check from '@/shared/components/Check';
+import Flex from '@/shared/layout/Flex';
+import Wrapper from '@/shared/layout/Wrapper';
+import Modal from '@/shared/components/Modal';
+import Text from '@/shared/components/Text';
 import * as S from './NotificationModal.styled';
 
 type CheckedNotification = {
@@ -33,8 +33,13 @@ interface NotificationState {
 interface NotificationModalProps {
   notification: NotificationState;
   handleCreateRoom: () => void;
+  isRoomCreateLoading: boolean;
 }
-const NotificationModal = ({ notification, handleCreateRoom }: NotificationModalProps) => {
+const NotificationModal = ({
+  notification,
+  handleCreateRoom,
+  isRoomCreateLoading,
+}: NotificationModalProps) => {
   return (
     <S.NotificationModalContainer>
       <Wrapper>
@@ -62,9 +67,10 @@ const NotificationModal = ({ notification, handleCreateRoom }: NotificationModal
             selected={true}
             onClick={handleCreateRoom}
             data-ga-id="create-event-button"
+            disabled={isRoomCreateLoading}
           >
             <Text variant="button" color="background">
-              방 만들기
+              {isRoomCreateLoading ? '생성 중...' : '방 만들기'}
             </Text>
           </Button>
         </Flex>

--- a/frontend/src/pages/CreateEvent/hooks/useCreateRoom.ts
+++ b/frontend/src/pages/CreateEvent/hooks/useCreateRoom.ts
@@ -1,11 +1,10 @@
 import { createChannelRoom, createRoom } from '@/apis/room/room';
 import { toCreateRoomInfo } from '@/apis/transform/toCreateRoomInfo';
-import { initialCreateRoomInfo } from '@/constants/initialRoomInfo';
-import { RoomInfo } from '@/pages/CreateEvent/types/roomInfo';
-import { useState, useCallback } from 'react';
+
+import { useCallback, useState } from 'react';
 import { useExtractQueryParams } from '../../../shared/hooks/common/useExtractQueryParams';
-import { TimeManager } from '@/shared/utils/common/TimeManager';
 import useFetch from '@/shared/hooks/common/useFetch';
+import { getRoomInfo } from '@/shared/store/createRoomStore';
 
 interface checkedNotification {
   created: boolean;
@@ -14,11 +13,6 @@ interface checkedNotification {
 }
 
 export const useCreateRoom = () => {
-  const [roomInfo, setRoomInfo] = useState<
-    RoomInfo & { time: { startTime: string; endTime: string } }
-  >(initialCreateRoomInfo);
-
-  //디스코드 관련 상태
   const { platformType, channelId } = useExtractQueryParams(['platformType', 'channelId'] as const);
   const [checkedNotification, setCheckedNotification] = useState<checkedNotification>({
     created: true,
@@ -26,13 +20,11 @@ export const useCreateRoom = () => {
     deadline: true,
   });
 
-  const isTimeRangeValid = TimeManager.isValidRange(roomInfo.time.startTime, roomInfo.time.endTime);
-
   const { triggerFetch: roomWithPlatformSubmit } = useFetch({
     context: 'roomInfoSubmit',
     requestFn: () =>
       createChannelRoom({
-        ...toCreateRoomInfo(roomInfo),
+        ...toCreateRoomInfo(getRoomInfo()),
         platformType: platformType as 'DISCORD' | 'SLACK',
         channelId: channelId || 'DISCORD',
         notification: checkedNotification,
@@ -41,50 +33,14 @@ export const useCreateRoom = () => {
 
   const { isLoading: isRoomSubmitLoading, triggerFetch: roomSubmit } = useFetch({
     context: 'roomInfoSubmit',
-    requestFn: () => createRoom(toCreateRoomInfo(roomInfo)),
+    requestFn: () => createRoom(toCreateRoomInfo(getRoomInfo())),
   });
-
-  const title = {
-    value: roomInfo.title,
-    set: (title: string) => setRoomInfo((prev) => ({ ...prev, title })),
-  };
-
-  const availableDateSlots = {
-    value: roomInfo.availableDateSlots,
-    set: (availableDateSlots: Set<string>) =>
-      setRoomInfo((prev) => ({ ...prev, availableDateSlots })),
-  };
-
-  const time = {
-    value: roomInfo.time,
-    valid: isTimeRangeValid,
-    set: ({ startTime, endTime }: { startTime: string; endTime: string }) =>
-      setRoomInfo((prev) => ({ ...prev, time: { startTime, endTime } })),
-  };
-
-  const deadline = {
-    value: roomInfo.deadline,
-    set: ({ date, time }: { date: string; time: string }) =>
-      setRoomInfo((prev) => ({ ...prev, deadline: { date, time } })),
-  };
 
   const notification = {
     value: checkedNotification,
     set: (id: keyof checkedNotification) =>
       setCheckedNotification((prev) => ({ ...prev, [id]: !prev[id] })),
   };
-
-  const isCalendarReady = roomInfo.availableDateSlots.size > 0;
-
-  const isBasicReady =
-    roomInfo.title.trim() !== '' &&
-    roomInfo.time.startTime.trim() !== '' &&
-    isTimeRangeValid &&
-    roomInfo.time.endTime.trim() !== '' &&
-    roomInfo.deadline.date.trim() !== '' &&
-    roomInfo.deadline.time.trim() !== '';
-
-  // 추후 어떤 조건이 빠졌는지도 반환하는 함수 만들어도 좋을 emt
 
   const roomInfoSubmit = useCallback(async () => {
     if (platformType && channelId) {
@@ -98,13 +54,7 @@ export const useCreateRoom = () => {
 
   return {
     platformType,
-    title,
-    availableDateSlots,
-    time,
-    deadline,
     notification,
-    isCalendarReady,
-    isBasicReady,
     roomInfoSubmit,
     isRoomSubmitLoading,
   };

--- a/frontend/src/pages/CreateEvent/hooks/useCreateRoom.ts
+++ b/frontend/src/pages/CreateEvent/hooks/useCreateRoom.ts
@@ -31,7 +31,7 @@ export const useCreateRoom = () => {
       }),
   });
 
-  const { isLoading: isRoomSubmitLoading, triggerFetch: roomSubmit } = useFetch({
+  const { triggerFetch: roomSubmit } = useFetch({
     context: 'roomInfoSubmit',
     requestFn: () => createRoom(toCreateRoomInfo(getRoomInfo())),
   });
@@ -56,7 +56,6 @@ export const useCreateRoom = () => {
     platformType,
     notification,
     roomInfoSubmit,
-    isRoomSubmitLoading,
   };
 };
 

--- a/frontend/src/pages/CreateEvent/hooks/useCreateRoom.ts
+++ b/frontend/src/pages/CreateEvent/hooks/useCreateRoom.ts
@@ -2,15 +2,15 @@ import { createChannelRoom, createRoom } from '@/apis/room/room';
 import { toCreateRoomInfo } from '@/apis/transform/toCreateRoomInfo';
 
 import { useCallback, useState } from 'react';
-import { useExtractQueryParams } from '../../../shared/hooks/common/useExtractQueryParams';
+import { useExtractQueryParams } from '@/shared/hooks/common/useExtractQueryParams';
 import useFetch from '@/shared/hooks/common/useFetch';
-import { getRoomInfo } from '@/shared/store/createRoomStore';
+import { getRoomInfo } from '@/pages/CreateEvent/store/createRoomStore';
 
-interface checkedNotification {
+type checkedNotification = {
   created: boolean;
   remind: boolean;
   deadline: boolean;
-}
+};
 
 export const useCreateRoom = () => {
   const { platformType, channelId } = useExtractQueryParams(['platformType', 'channelId'] as const);

--- a/frontend/src/pages/CreateEvent/hooks/useCreateRoomController.ts
+++ b/frontend/src/pages/CreateEvent/hooks/useCreateRoomController.ts
@@ -1,66 +1,21 @@
-import useShakeAnimation from '@/shared/hooks/common/useShakeAnimation';
-import { useMemo, useRef, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import useCreateRoom from './useCreateRoom';
-import { checkBasicReady, checkCalendarReady } from '../utils/CreateRoomValidator';
 import { showToast } from '@/shared/store/toastStore';
 import useEnterKeySubmit from '@/shared/hooks/common/useEnterKeySubmit';
-
-type FieldType = 'all' | 'calendar' | 'basic';
-
-interface showCreateRoomValidationErrorType {
-  type?: 'warning';
-  field: FieldType;
-}
-
-const validationFailureMessages: Record<FieldType, string> = {
-  all: '날짜와 기본 설정을 선택해주세요!',
-  calendar: '날짜를 선택해주세요!',
-  basic: '제목과 시간을 선택해주세요!',
-};
+import useCreateRoomValidation from './useCreateRoomValidation';
 
 const useCreateRoomController = () => {
-  const isRoutingRef = useRef(false);
-  const showValidationBorder = useRef<boolean>(false);
   const [isNotificationModalOpen, setIsNotificationModalOpen] = useState(false);
+
   const [isRoomCreateLoading, setIsRoomCreateLoading] = useState(false);
 
   const navigate = useNavigate();
-  const { platformType, roomInfoSubmit, isRoomSubmitLoading, notification } = useCreateRoom();
-  const { shouldShake, handleShouldShake } = useShakeAnimation();
 
-  const isCalendarValid = !showValidationBorder.current || checkCalendarReady();
-  const isBasicValid = !showValidationBorder.current || checkBasicReady();
+  const { platformType, roomInfoSubmit, notification } = useCreateRoom();
 
-  const isRoomCreateLoading = isRoomSubmitLoading || isRoutingRef.current;
-
-  const showCreateRoomValidationError = ({
-    type = 'warning',
-    field,
-  }: showCreateRoomValidationErrorType) => {
-    showToast({
-      type,
-      message: validationFailureMessages[field],
-    });
-    showValidationBorder.current = true;
-    handleShouldShake();
-  };
-
-  const validateCreateRoom = () => {
-    if (!checkCalendarReady() && !checkBasicReady()) {
-      showCreateRoomValidationError({ field: 'all' });
-      return false;
-    }
-    if (!checkCalendarReady()) {
-      showCreateRoomValidationError({ field: 'calendar' });
-      return false;
-    }
-    if (!checkBasicReady()) {
-      showCreateRoomValidationError({ field: 'basic' });
-      return false;
-    }
-    return true;
-  };
+  const { shouldShake, isCalendarValid, isBasicValid, validateCreateRoom } =
+    useCreateRoomValidation();
 
   const onSubmit = async () => {
     setIsRoomCreateLoading(true);

--- a/frontend/src/pages/CreateEvent/hooks/useCreateRoomController.ts
+++ b/frontend/src/pages/CreateEvent/hooks/useCreateRoomController.ts
@@ -1,0 +1,127 @@
+import useShakeAnimation from '@/shared/hooks/common/useShakeAnimation';
+import { useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router';
+import useCreateRoom from './useCreateRoom';
+import { checkBasicReady, checkCalendarReady } from '../utils/CreateRoomValidator';
+import { showToast } from '@/shared/store/toastStore';
+import useEnterKeySubmit from '@/shared/hooks/common/useEnterKeySubmit';
+
+type FieldType = 'all' | 'calendar' | 'basic';
+
+interface showCreateRoomValidationErrorType {
+  type?: 'warning';
+  field: FieldType;
+}
+
+const validationFailureMessages: Record<FieldType, string> = {
+  all: '날짜와 기본 설정을 선택해주세요!',
+  calendar: '날짜를 선택해주세요!',
+  basic: '제목과 시간을 선택해주세요!',
+};
+
+const useCreateRoomController = () => {
+  const isRoutingRef = useRef(false);
+  const showValidationBorder = useRef<boolean>(false);
+  const [isNotificationModalOpen, setIsNotificationModalOpen] = useState(false);
+
+  const navigate = useNavigate();
+  const { platformType, roomInfoSubmit, isRoomSubmitLoading, notification } = useCreateRoom();
+  const { shouldShake, handleShouldShake } = useShakeAnimation();
+
+  const isCalendarValid = !showValidationBorder.current || checkCalendarReady();
+  const isBasicValid = !showValidationBorder.current || checkBasicReady();
+
+  const isRoomCreateLoading = isRoomSubmitLoading || isRoutingRef.current;
+
+  const showCreateRoomValidationError = ({
+    type = 'warning',
+    field,
+  }: showCreateRoomValidationErrorType) => {
+    showToast({
+      type,
+      message: validationFailureMessages[field],
+    });
+    showValidationBorder.current = true;
+    handleShouldShake();
+  };
+
+  const validateCreateRoom = () => {
+    if (!checkCalendarReady() && !checkBasicReady()) {
+      showCreateRoomValidationError({ field: 'all' });
+      return false;
+    }
+    if (!checkCalendarReady()) {
+      showCreateRoomValidationError({ field: 'calendar' });
+      return false;
+    }
+    if (!checkBasicReady()) {
+      showCreateRoomValidationError({ field: 'basic' });
+      return false;
+    }
+    return true;
+  };
+
+  const onSubmit = async () => {
+    const session = await roomInfoSubmit();
+    isRoutingRef.current = true;
+    if (session) {
+      showToast({ type: 'success', message: '방 생성이 완료되었습니다.' });
+      navigate(`/check?id=${session}`, { replace: true });
+    }
+  };
+
+  const handleCreateRoom = async () => {
+    if (!validateCreateRoom()) return;
+    if (platformType) {
+      setIsNotificationModalOpen(true);
+      return;
+    }
+    await onSubmit();
+  };
+
+  const handlePlatformCreateRoom = async () => {
+    setIsNotificationModalOpen(false);
+    await onSubmit();
+  };
+
+  const { buttonRef } = useEnterKeySubmit({ callback: handleCreateRoom });
+
+  const CreateRoomInterface = useMemo(
+    () => ({
+      notificationModal: {
+        isOpen: isNotificationModalOpen,
+        setIsOpen: setIsNotificationModalOpen,
+      },
+      isValid: {
+        calendar: isCalendarValid,
+        basic: isBasicValid,
+      },
+
+      checkNotification: notification,
+
+      animation: { shake: shouldShake },
+      submitButtonRef: buttonRef,
+
+      isRoomCreateLoading,
+      handler: {
+        createRoom: handleCreateRoom,
+        platformCreateRoom: handlePlatformCreateRoom,
+      },
+    }),
+    [
+      isNotificationModalOpen,
+      isCalendarValid,
+      isBasicValid,
+      notification,
+      shouldShake,
+      buttonRef,
+      isRoomCreateLoading,
+      handleCreateRoom,
+      handlePlatformCreateRoom,
+    ]
+  );
+
+  return CreateRoomInterface;
+};
+
+export default useCreateRoomController;

--- a/frontend/src/pages/CreateEvent/hooks/useCreateRoomController.ts
+++ b/frontend/src/pages/CreateEvent/hooks/useCreateRoomController.ts
@@ -23,6 +23,7 @@ const useCreateRoomController = () => {
   const isRoutingRef = useRef(false);
   const showValidationBorder = useRef<boolean>(false);
   const [isNotificationModalOpen, setIsNotificationModalOpen] = useState(false);
+  const [isRoomCreateLoading, setIsRoomCreateLoading] = useState(false);
 
   const navigate = useNavigate();
   const { platformType, roomInfoSubmit, isRoomSubmitLoading, notification } = useCreateRoom();
@@ -62,11 +63,13 @@ const useCreateRoomController = () => {
   };
 
   const onSubmit = async () => {
+    setIsRoomCreateLoading(true);
     const session = await roomInfoSubmit();
-    isRoutingRef.current = true;
     if (session) {
       showToast({ type: 'success', message: '방 생성이 완료되었습니다.' });
       navigate(`/check?id=${session}`, { replace: true });
+    } else {
+      setIsRoomCreateLoading(false);
     }
   };
 

--- a/frontend/src/pages/CreateEvent/hooks/useCreateRoomValidation.ts
+++ b/frontend/src/pages/CreateEvent/hooks/useCreateRoomValidation.ts
@@ -1,0 +1,61 @@
+import useShakeAnimation from '@/shared/hooks/common/useShakeAnimation';
+import { checkBasicReady, checkCalendarReady } from '../utils/CreateRoomValidator';
+import { useRef } from 'react';
+import { showToast } from '@/shared/store/toastStore';
+
+interface showCreateRoomValidationErrorType {
+  type?: 'warning';
+  field: FieldType;
+}
+
+type FieldType = 'all' | 'calendar' | 'basic';
+
+const validationFailureMessages: Record<FieldType, string> = {
+  all: '날짜와 기본 설정을 선택해주세요!',
+  calendar: '날짜를 선택해주세요!',
+  basic: '제목과 시간을 선택해주세요!',
+};
+
+const useCreateRoomValidation = () => {
+  const { shouldShake, handleShouldShake } = useShakeAnimation();
+  const showValidationBorder = useRef<boolean>(false);
+  const isCalendarValid = !showValidationBorder.current || checkCalendarReady();
+  const isBasicValid = !showValidationBorder.current || checkBasicReady();
+
+  const showCreateRoomValidationError = ({
+    type = 'warning',
+    field,
+  }: showCreateRoomValidationErrorType) => {
+    showToast({
+      type,
+      message: validationFailureMessages[field],
+    });
+    showValidationBorder.current = true;
+    handleShouldShake();
+  };
+
+  const validateCreateRoom = () => {
+    if (!checkCalendarReady() && !checkBasicReady()) {
+      showCreateRoomValidationError({ field: 'all' });
+      return false;
+    }
+    if (!checkCalendarReady()) {
+      showCreateRoomValidationError({ field: 'calendar' });
+      return false;
+    }
+    if (!checkBasicReady()) {
+      showCreateRoomValidationError({ field: 'basic' });
+      return false;
+    }
+    return true;
+  };
+
+  return {
+    shouldShake,
+    isCalendarValid,
+    isBasicValid,
+    validateCreateRoom,
+  };
+};
+
+export default useCreateRoomValidation;

--- a/frontend/src/pages/CreateEvent/hooks/useMobileCreateRoomController.ts
+++ b/frontend/src/pages/CreateEvent/hooks/useMobileCreateRoomController.ts
@@ -1,0 +1,135 @@
+import useShakeAnimation from '@/shared/hooks/common/useShakeAnimation';
+import { useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router';
+import useCreateRoom from './useCreateRoom';
+import { checkBasicReady, checkCalendarReady } from '../utils/CreateRoomValidator';
+import { showToast } from '@/shared/store/toastStore';
+import useFunnelWithHistory from '@/shared/hooks/Funnel/useFunnelWithHistory';
+
+type FieldType = 'calendar' | 'basic';
+
+interface showCreateRoomValidationErrorType {
+  type?: 'warning';
+  field: FieldType;
+}
+
+const validationFailureMessages: Record<FieldType, string> = {
+  calendar: '날짜를 선택해주세요!',
+  basic: '제목과 시간을 선택해주세요!',
+};
+const STEP = ['메인 화면', '캘린더 선택 화면', '제목 및 시간 선택 화면'] as const;
+
+const useMobileCreateRoomController = () => {
+  const isRoutingRef = useRef(false);
+  const showValidationBorder = useRef({
+    calendar: false,
+    basic: false,
+  });
+  const [isNotificationModalOpen, setIsNotificationModalOpen] = useState(false);
+
+  const navigate = useNavigate();
+  const { platformType, roomInfoSubmit, isRoomSubmitLoading, notification } = useCreateRoom();
+  const { shouldShake, handleShouldShake } = useShakeAnimation();
+  const { Funnel, step, stepNext, stepPrev } = useFunnelWithHistory(STEP);
+
+  const isCalendarValid = !showValidationBorder.current.calendar || checkCalendarReady();
+  const isBasicValid = !showValidationBorder.current.basic || checkBasicReady();
+
+  const isRoomCreateLoading = isRoomSubmitLoading || isRoutingRef.current;
+
+  const showCreateRoomValidationError = ({
+    type = 'warning',
+    field,
+  }: showCreateRoomValidationErrorType) => {
+    showToast({ type: 'warning', message: validationFailureMessages[field] });
+    showValidationBorder.current[field] = true;
+    handleShouldShake();
+    return;
+  };
+
+  const onSubmit = async () => {
+    const session = await roomInfoSubmit();
+    isRoutingRef.current = true;
+    if (session) {
+      showToast({ type: 'success', message: '방 생성이 완료되었습니다.' });
+      navigate(`/check?id=${session}`, { replace: true });
+    }
+  };
+
+  const handleCreateRoom = async () => {
+    if (platformType) {
+      setIsNotificationModalOpen(true);
+      return;
+    }
+    await onSubmit();
+  };
+
+  const handlePlatformCreateRoom = async () => {
+    setIsNotificationModalOpen(false);
+    await onSubmit();
+  };
+
+  const handleNextStep = async (type: 'calendar' | 'basic') => {
+    if (type === 'calendar') {
+      if (!checkCalendarReady()) {
+        showCreateRoomValidationError({ field: 'calendar' });
+        return; // 유효하지 않으면 종료
+      }
+      stepNext();
+      return;
+    }
+
+    if (type === 'basic') {
+      if (!checkBasicReady()) {
+        showCreateRoomValidationError({ field: 'basic' });
+        return;
+      }
+      await handleCreateRoom(); // 최종 단계는 생성으로 종료
+      return;
+    }
+  };
+  const CreateRoomInterface = useMemo(
+    () => ({
+      notificationModal: {
+        isOpen: isNotificationModalOpen,
+        setIsOpen: setIsNotificationModalOpen,
+      },
+      isValid: {
+        calendar: isCalendarValid,
+        basic: isBasicValid,
+      },
+
+      checkNotification: notification,
+
+      animation: { shake: shouldShake },
+
+      isRoomCreateLoading,
+
+      handler: {
+        createRoom: handleCreateRoom,
+        platformCreateRoom: handlePlatformCreateRoom,
+        nextStep: handleNextStep,
+      },
+      funnel: {
+        Funnel,
+        step,
+        stepNext,
+        stepPrev,
+      },
+    }),
+    [
+      isNotificationModalOpen,
+      isCalendarValid,
+      isBasicValid,
+      notification,
+      shouldShake,
+      isRoomCreateLoading,
+      handleCreateRoom,
+      handlePlatformCreateRoom,
+    ]
+  );
+
+  return CreateRoomInterface;
+};
+
+export default useMobileCreateRoomController;

--- a/frontend/src/pages/CreateEvent/hooks/useMobileCreateRoomController.ts
+++ b/frontend/src/pages/CreateEvent/hooks/useMobileCreateRoomController.ts
@@ -1,47 +1,26 @@
-import useShakeAnimation from '@/shared/hooks/common/useShakeAnimation';
-import { useMemo, useRef, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import useCreateRoom from './useCreateRoom';
 import { checkBasicReady, checkCalendarReady } from '../utils/CreateRoomValidator';
 import { showToast } from '@/shared/store/toastStore';
 import useFunnelWithHistory from '@/shared/hooks/Funnel/useFunnelWithHistory';
+import useMobileCreateRoomValidation from './useMobileCreateRoomValidation';
 
-type FieldType = 'calendar' | 'basic';
-
-interface showCreateRoomValidationErrorType {
-  type?: 'warning';
-  field: FieldType;
-}
-
-const validationFailureMessages: Record<FieldType, string> = {
-  calendar: '날짜를 선택해주세요!',
-  basic: '제목과 시간을 선택해주세요!',
-};
 const STEP = ['메인 화면', '캘린더 선택 화면', '제목 및 시간 선택 화면'] as const;
 
 const useMobileCreateRoomController = () => {
   const [isRoomCreateLoading, setIsRoomCreateLoading] = useState(false);
+
   const [isNotificationModalOpen, setIsNotificationModalOpen] = useState(false);
 
   const navigate = useNavigate();
-  const { platformType, roomInfoSubmit, isRoomSubmitLoading, notification } = useCreateRoom();
-  const { shouldShake, handleShouldShake } = useShakeAnimation();
+
+  const { platformType, roomInfoSubmit, notification } = useCreateRoom();
+
   const { Funnel, step, stepNext, stepPrev } = useFunnelWithHistory(STEP);
 
-  const isCalendarValid = !showValidationBorder.current.calendar || checkCalendarReady();
-  const isBasicValid = !showValidationBorder.current.basic || checkBasicReady();
-
-  const isRoomCreateLoading = isRoomSubmitLoading || isRoutingRef.current;
-
-  const showCreateRoomValidationError = ({
-    type = 'warning',
-    field,
-  }: showCreateRoomValidationErrorType) => {
-    showToast({ type: 'warning', message: validationFailureMessages[field] });
-    showValidationBorder.current[field] = true;
-    handleShouldShake();
-    return;
-  };
+  const { shouldShake, isCalendarValid, isBasicValid, showCreateRoomValidationError } =
+    useMobileCreateRoomValidation();
 
   const onSubmit = async () => {
     setIsRoomCreateLoading(true);
@@ -116,6 +95,11 @@ const useMobileCreateRoomController = () => {
       },
     }),
     [
+      Funnel,
+      step,
+      stepNext,
+      stepPrev,
+      handleNextStep,
       isNotificationModalOpen,
       isCalendarValid,
       isBasicValid,

--- a/frontend/src/pages/CreateEvent/hooks/useMobileCreateRoomController.ts
+++ b/frontend/src/pages/CreateEvent/hooks/useMobileCreateRoomController.ts
@@ -20,11 +20,7 @@ const validationFailureMessages: Record<FieldType, string> = {
 const STEP = ['메인 화면', '캘린더 선택 화면', '제목 및 시간 선택 화면'] as const;
 
 const useMobileCreateRoomController = () => {
-  const isRoutingRef = useRef(false);
-  const showValidationBorder = useRef({
-    calendar: false,
-    basic: false,
-  });
+  const [isRoomCreateLoading, setIsRoomCreateLoading] = useState(false);
   const [isNotificationModalOpen, setIsNotificationModalOpen] = useState(false);
 
   const navigate = useNavigate();
@@ -48,11 +44,13 @@ const useMobileCreateRoomController = () => {
   };
 
   const onSubmit = async () => {
+    setIsRoomCreateLoading(true);
     const session = await roomInfoSubmit();
-    isRoutingRef.current = true;
     if (session) {
       showToast({ type: 'success', message: '방 생성이 완료되었습니다.' });
       navigate(`/check?id=${session}`, { replace: true });
+    } else {
+      setIsRoomCreateLoading(false);
     }
   };
 

--- a/frontend/src/pages/CreateEvent/hooks/useMobileCreateRoomValidation.ts
+++ b/frontend/src/pages/CreateEvent/hooks/useMobileCreateRoomValidation.ts
@@ -1,0 +1,44 @@
+import useShakeAnimation from '@/shared/hooks/common/useShakeAnimation';
+import { useRef } from 'react';
+import { checkBasicReady, checkCalendarReady } from '../utils/CreateRoomValidator';
+import { showToast } from '@/shared/store/toastStore';
+
+type FieldType = 'calendar' | 'basic';
+interface showCreateRoomValidationErrorType {
+  type?: 'warning';
+  field: FieldType;
+}
+
+const validationFailureMessages: Record<FieldType, string> = {
+  calendar: '날짜를 선택해주세요!',
+  basic: '제목과 시간을 선택해주세요!',
+};
+
+const useMobileCreateRoomValidation = () => {
+  const showValidationBorder = useRef({
+    calendar: false,
+    basic: false,
+  });
+  const { shouldShake, handleShouldShake } = useShakeAnimation();
+  const isCalendarValid = !showValidationBorder.current.calendar || checkCalendarReady();
+  const isBasicValid = !showValidationBorder.current.basic || checkBasicReady();
+
+  const showCreateRoomValidationError = ({
+    type = 'warning',
+    field,
+  }: showCreateRoomValidationErrorType) => {
+    showToast({ type, message: validationFailureMessages[field] });
+    showValidationBorder.current[field] = true;
+    handleShouldShake();
+    return;
+  };
+
+  return {
+    shouldShake,
+    isCalendarValid,
+    isBasicValid,
+    showCreateRoomValidationError,
+  };
+};
+
+export default useMobileCreateRoomValidation;

--- a/frontend/src/pages/CreateEvent/store/createRoomStore.ts
+++ b/frontend/src/pages/CreateEvent/store/createRoomStore.ts
@@ -1,15 +1,10 @@
-import type { RoomInfo } from '@/pages/CreateEvent/types/roomInfo';
-import createStore from './createStore';
-import { initialCreateRoomInfo } from '@/constants/initialRoomInfo';
 import { useSyncExternalStore } from 'react';
-import { TimeManager } from '../utils/common/TimeManager';
-
-interface CreateRoomStoreType extends RoomInfo {
-  time: { startTime: string; endTime: string };
-}
+import type { CreateRoomInfoType } from '@/pages/CreateEvent/types/roomInfo';
+import { initialCreateRoomInfo } from '@/constants/initialRoomInfo';
+import createStore from '@/shared/store/createStore';
 
 const createRoomStore = () => {
-  const store = createStore<CreateRoomStoreType>(initialCreateRoomInfo);
+  const store = createStore<CreateRoomInfoType>(initialCreateRoomInfo);
 
   const onChangeTitle = (title: string) => {
     store.setState((prev) => ({ ...prev, title }));
@@ -22,6 +17,7 @@ const createRoomStore = () => {
   const onChangeTime = (time: { startTime: string; endTime: string }) => {
     store.setState((prev) => ({ ...prev, time }));
   };
+
   const onChangeDeadline = (deadline: { date: string; time: string }) => {
     store.setState((prev) => ({ ...prev, deadline }));
   };
@@ -37,13 +33,13 @@ const createRoomStore = () => {
 
 const roomStore = createRoomStore();
 
-export const getRoomInfo = () => roomStore.getSnapshot();
+export const getRoomInfo = roomStore.getSnapshot;
 
 export const onChangeTitle = roomStore.onChangeTitle;
 export const onChangeTime = roomStore.onChangeTime;
 export const onChangeAvailableDateSlots = roomStore.onChangeAvailableDateSlots;
 export const onChangeDeadline = roomStore.onChangeDeadline;
 
-export const useRoomSelector = <T extends keyof CreateRoomStoreType>(selector: T) => {
+export const useRoomSelector = <T extends keyof CreateRoomInfoType>(selector: T) => {
   return useSyncExternalStore(roomStore.subscribe, () => getRoomInfo()[selector]);
 };

--- a/frontend/src/pages/CreateEvent/types/roomInfo.ts
+++ b/frontend/src/pages/CreateEvent/types/roomInfo.ts
@@ -3,3 +3,6 @@ export interface RoomInfo {
   availableDateSlots: Set<string>;
   deadline: { date: string; time: string };
 }
+export interface CreateRoomInfoType extends RoomInfo {
+  time: { startTime: string; endTime: string };
+}

--- a/frontend/src/pages/CreateEvent/utils/CreateRoomValidator.ts
+++ b/frontend/src/pages/CreateEvent/utils/CreateRoomValidator.ts
@@ -1,0 +1,18 @@
+import { getRoomInfo } from '@/shared/store/createRoomStore';
+import { TimeManager } from '@/shared/utils/common/TimeManager';
+
+export const checkTimeRangeValid = () =>
+  TimeManager.isValidRange(getRoomInfo().time.startTime, getRoomInfo().time.endTime);
+
+export const checkCalendarReady = () => getRoomInfo().availableDateSlots.size > 0;
+
+export const checkBasicReady = () => {
+  return (
+    getRoomInfo().title.trim() !== '' &&
+    getRoomInfo().time.startTime.trim() !== '' &&
+    getRoomInfo().time.endTime.trim() !== '' &&
+    checkTimeRangeValid() &&
+    getRoomInfo().deadline.date.trim() !== '' &&
+    getRoomInfo().deadline.time.trim() !== ''
+  );
+};

--- a/frontend/src/pages/CreateEvent/utils/CreateRoomValidator.ts
+++ b/frontend/src/pages/CreateEvent/utils/CreateRoomValidator.ts
@@ -1,4 +1,4 @@
-import { getRoomInfo } from '@/shared/store/createRoomStore';
+import { getRoomInfo } from '@/pages/CreateEvent/store/createRoomStore';
 import { TimeManager } from '@/shared/utils/common/TimeManager';
 
 export const checkTimeRangeValid = () =>

--- a/frontend/src/shared/store/createRoomStore.ts
+++ b/frontend/src/shared/store/createRoomStore.ts
@@ -1,0 +1,49 @@
+import type { RoomInfo } from '@/pages/CreateEvent/types/roomInfo';
+import createStore from './createStore';
+import { initialCreateRoomInfo } from '@/constants/initialRoomInfo';
+import { useSyncExternalStore } from 'react';
+import { TimeManager } from '../utils/common/TimeManager';
+
+interface CreateRoomStoreType extends RoomInfo {
+  time: { startTime: string; endTime: string };
+}
+
+const createRoomStore = () => {
+  const store = createStore<CreateRoomStoreType>(initialCreateRoomInfo);
+
+  const onChangeTitle = (title: string) => {
+    store.setState((prev) => ({ ...prev, title }));
+  };
+
+  const onChangeAvailableDateSlots = (availableDateSlots: Set<string>) => {
+    store.setState((prev) => ({ ...prev, availableDateSlots }));
+  };
+
+  const onChangeTime = (time: { startTime: string; endTime: string }) => {
+    store.setState((prev) => ({ ...prev, time }));
+  };
+  const onChangeDeadline = (deadline: { date: string; time: string }) => {
+    store.setState((prev) => ({ ...prev, deadline }));
+  };
+
+  return {
+    ...store,
+    onChangeTitle,
+    onChangeAvailableDateSlots,
+    onChangeTime,
+    onChangeDeadline,
+  };
+};
+
+const roomStore = createRoomStore();
+
+export const getRoomInfo = () => roomStore.getSnapshot();
+
+export const onChangeTitle = roomStore.onChangeTitle;
+export const onChangeTime = roomStore.onChangeTime;
+export const onChangeAvailableDateSlots = roomStore.onChangeAvailableDateSlots;
+export const onChangeDeadline = roomStore.onChangeDeadline;
+
+export const useRoomSelector = <T extends keyof CreateRoomStoreType>(selector: T) => {
+  return useSyncExternalStore(roomStore.subscribe, () => getRoomInfo()[selector]);
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- closes : #617 

## 📝 작업 내용
- [x]  Store 기반 `roomInfo` 상태 관리 전환
- [x]  입력 값에 대한 Validation 로직 유틸 함수로 분리
- [x]  `useCreateRoomController` 추가
    - [x]  isRoomCreateLoading 상태 간소화
    - [x]  입력값 validation에 대한 토스트 띄우는 로직 공통 함수로 분리
    - [x]  return 값 객체화
- [x]  `useMobileCreateRoomController` 분리

## 작업 상세 내용

### 1. Store 기반 `roomInfo` 상태 관리 전환

목적: 불필한 리렌더링 방지 및 상태 관리 중앙화

작업 내용

- 초기에는 `roomInfo` 전부를 store로 관리하려 했지만
- 채널 정보까지 store에 넣으면 기본 `roomInfo` 타입 통합에 어려움이 있어 채널 정보는 기존의 useState 상태를 유지하였습니다.
- `roomInfo`의 하위 데이터는 사용처에 최대한 가까이에서 호출하여 사용하도록 수정해 전체 settings 컴포넌트의 불필요한 리렌더링을 줄였습니다.

현재 구현

```tsx
// createRoomStore.ts
const store = createStore<CreateRoomInfoType>(initialCreateRoomInfo);

// 각 상태 데이터를 구독하기 위한 함수
export const useRoomSelector = <T extends keyof CreateRoomInfoType>(selector: T) => {
  return useSyncExternalStore(roomStore.subscribe, () => getRoomInfo()[selector]);
};

```

---

## 2. Validation 로직 유틸 함수로 분리

목적: 관심사 분리

작업 내용

- 방 정보 입력값에 대한 validation 로직을 유틸 함수로 분리하였습니다. (`createRoomValidator.ts`)

한계

- validation이 전체 `roomInfo`를 조회하므로 호출 지점에서 전체 리렌더가 발생할 수 있습니다.

---

### 3. `useCreateRoomController` 추가

목적

- 중복 로직 분리, 흐름 명확화
- 지역성 있는 함수·변수는 의미가 드러나도록 재명명
- 중복 코드는 함수로 추출해 초기화후 중복 코드 삭제

작업 내용

- 기존 `CreateEventPage`에 있던 상태 및 핸들러를 useCreateRoomController 훅으로 통합하였습니다.
- 훅의 return 값을 객체로 묶어줌으로써 사용처에서 깔끔하고 직관적으로 사용할 수 있도록 수정하였습니다.

```jsx
// 컨트롤러 훅 내부 객체화된 return 값
const CreateRoomInterface = {
    notificationModal: {
      isOpen: isNotificationModalOpen,
      setIsOpen: setIsNotificationModalOpen,
    },
    isValid: {
      calendar: isCalendarValid,
      basic: isBasicValid,
    },
    checkNotification: notification,
    submitButtonRef: buttonRef,
    isRoomCreateLoading,
    handler: {
      createRoom: handleCreateRoom,
      platformCreateRoom: handlePlatformCreateRoom,
    },
  };
  
  // createEventPage.tsx에서 사용할 때 
  const {
  notificationModal,    // 모달 상태
  checkNotification,    // 알림 설정
  isValid,              // 검증 상태
  animation,            // 애니메이션 상태
  submitButtonRef,      // 버튼 레퍼런스
  isRoomCreateLoading,  // 로딩 상태
  handler,              // 이벤트 핸들러
} = useCreateRoomController();
```

---

### 4. `useMobileCreateRoomController` 분리

작업 내용

- 데스크탑에 사용하고 있는 useCreateRoomController 훅에 Funnel 로직과 핸들러를 통합하려 했지만,
- 모바일에서 step에 따른 입력값 validation 로직이 미묘하게 달라 통합을 보류하고 별도의 컨트롤러 훅으로 분리한 상태입니다.
- 모바일 리팩토링 시점**에 훅 통합에 대해 다시 한번 이야기해보면 좋을 것 같습니다.

## 💬 리뷰 요구사항
- 컨트롤러 훅 내부의 Validation 상태 관리
    - showValidationBorder와 checkCalendarReady/checkBasicReady 두 boolean 값을 하나로 통합하려 했지만
        1. 페이지 첫 노출 시 border는 숨김
        2. submit 실패 시 border 표시
        3. shake 애니메이션 동작
            
            세가지 조건 때문에 세가지 상태를 분리해서 유지해야 합니다.
            
        
        ```tsx
        const { shouldShake, handleShouldShake } = useShakeAnimation();
          
        const isCalendarValid = !showValidationBorder.current || checkCalendarReady();
        const isBasicValid    = !showValidationBorder.current || checkBasicReady();
        ```
        
        > 혹시 더 상태 단순화를 할 수 있다면 리뷰로 이야기해보면 좋을 것 같습니다.
        > 
- controller 훅의 return 값은 객체화 함으로써 사용처를 깔끔하게 유지할 수 있지만 사용처에서 상반된 관심사를 보이고 있기도 하고, 컨트롤러 훅의 가독성이 떨어진다고 느낄 수도 있을 것 같아서 호이초이와 메이토는 이 부분에 대해서 어떻게 생각하는지 이야기 나눠보고 싶습니다.