### PR TITLE
Room 생성시 DateSlot/TimeSlot Batch Insert 적용

### DIFF
--- a/application/src/main/java/com/estime/room/application/dto/input/ConnectedRoomCreateInput.java
+++ b/application/src/main/java/com/estime/room/application/dto/input/ConnectedRoomCreateInput.java
@@ -9,8 +9,8 @@ import java.util.List;
 
 public record ConnectedRoomCreateInput(
         String title,
-        List<DateSlot> availableDates,
-        List<TimeSlot> availableTimes,
+        List<DateSlot> availableDateSlots,
+        List<TimeSlot> availableTimeSlots,
         LocalDateTime deadline,
         PlatformType type,
         String channelId,
@@ -18,6 +18,6 @@ public record ConnectedRoomCreateInput(
 ) {
 
     public RoomCreateInput toRoomCreateInput() {
-        return new RoomCreateInput(title, availableDates, availableTimes, deadline);
+        return new RoomCreateInput(title, availableDateSlots, availableTimeSlots, deadline);
     }
 }

--- a/application/src/main/java/com/estime/room/application/dto/input/RoomCreateInput.java
+++ b/application/src/main/java/com/estime/room/application/dto/input/RoomCreateInput.java
@@ -1,6 +1,5 @@
 package com.estime.room.application.dto.input;
 
-import com.estime.room.Room;
 import com.estime.room.slot.DateSlot;
 import com.estime.room.slot.TimeSlot;
 import java.time.LocalDateTime;
@@ -12,8 +11,4 @@ public record RoomCreateInput(
         List<TimeSlot> availableTimeSlots,
         LocalDateTime deadline
 ) {
-
-    public Room toEntity() {
-        return Room.withoutId(title, availableDateSlots, availableTimeSlots, deadline);
-    }
 }

--- a/application/src/main/java/com/estime/room/infrastructure/JdbcSlotBatchRepository.java
+++ b/application/src/main/java/com/estime/room/infrastructure/JdbcSlotBatchRepository.java
@@ -1,0 +1,51 @@
+package com.estime.room.infrastructure;
+
+import com.estime.room.SlotBatchRepository;
+import com.estime.room.slot.DateSlot;
+import com.estime.room.slot.TimeSlot;
+import java.sql.Time;
+import java.util.Collection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class JdbcSlotBatchRepository implements SlotBatchRepository {
+
+    private static final int BATCH_SIZE = 50;
+    private static final String INSERT_DATE_SLOT_SQL = "INSERT INTO room_available_date_slot (room_id, start_at) VALUES (?, ?)";
+    private static final String INSERT_TIME_SLOT_SQL = "INSERT INTO room_available_time_slot (room_id, start_at) VALUES (?, ?)";
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public void batchInsertSlots(final Long roomId, final Collection<DateSlot> dateSlots, final Collection<TimeSlot> timeSlots) {
+        batchInsertDateSlots(roomId, dateSlots);
+        batchInsertTimeSlots(roomId, timeSlots);
+    }
+
+    private void batchInsertDateSlots(final Long roomId, final Collection<DateSlot> dateSlots) {
+        jdbcTemplate.batchUpdate(
+                INSERT_DATE_SLOT_SQL,
+                dateSlots,
+                BATCH_SIZE,
+                (ps, slot) -> {
+                    ps.setLong(1, roomId);
+                    ps.setObject(2, slot.getStartAt());
+                }
+        );
+    }
+
+    private void batchInsertTimeSlots(final Long roomId, final Collection<TimeSlot> timeSlots) {
+        jdbcTemplate.batchUpdate(
+                INSERT_TIME_SLOT_SQL,
+                timeSlots,
+                BATCH_SIZE,
+                (ps, slot) -> {
+                    ps.setLong(1, roomId);
+                    ps.setTime(2, Time.valueOf(slot.getStartAt()));
+                }
+        );
+    }
+}

--- a/application/src/main/java/com/estime/room/infrastructure/RoomRepositoryAdapter.java
+++ b/application/src/main/java/com/estime/room/infrastructure/RoomRepositoryAdapter.java
@@ -28,6 +28,8 @@ public class RoomRepositoryAdapter implements RoomRepository {
     public Optional<Room> findBySession(final RoomSession session) {
         return Optional.ofNullable(
                 queryFactory.selectFrom(room)
+                        .leftJoin(room.availableDateSlots).fetchJoin()
+                        .leftJoin(room.availableTimeSlots).fetchJoin()
                         .where(room.session.eq(session))
                         .fetchOne()
         );

--- a/core/src/main/java/com/estime/room/Room.java
+++ b/core/src/main/java/com/estime/room/Room.java
@@ -20,6 +20,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import lombok.AccessLevel;
@@ -88,6 +89,23 @@ public class Room extends BaseEntity {
         );
     }
 
+    public static Room withoutSlots(
+            final String title,
+            final LocalDateTime deadline
+    ) {
+        validateTitleAndDeadline(title, deadline);
+        final String trimmedTitle = title.trim();
+        validateTitle(trimmedTitle);
+        validateDeadline(deadline);
+        return new Room(
+                RoomSession.generate(),
+                trimmedTitle,
+                Collections.emptySet(),
+                Collections.emptySet(),
+                deadline
+        );
+    }
+
     private static void validateNull(
             final String title,
             final List<DateSlot> availableDateSlots,
@@ -98,6 +116,13 @@ public class Room extends BaseEntity {
                 .add(Fields.title, title)
                 .add(Fields.availableDateSlots, availableDateSlots)
                 .add(Fields.availableTimeSlots, availableTimeSlots)
+                .add(Fields.deadline, deadline)
+                .validateNull();
+    }
+
+    private static void validateTitleAndDeadline(final String title, final LocalDateTime deadline) {
+        Validator.builder()
+                .add(Fields.title, title)
                 .add(Fields.deadline, deadline)
                 .validateNull();
     }

--- a/core/src/main/java/com/estime/room/SlotBatchRepository.java
+++ b/core/src/main/java/com/estime/room/SlotBatchRepository.java
@@ -1,0 +1,10 @@
+package com.estime.room;
+
+import com.estime.room.slot.DateSlot;
+import com.estime.room.slot.TimeSlot;
+import java.util.Collection;
+
+public interface SlotBatchRepository {
+
+    void batchInsertSlots(final Long roomId, final Collection<DateSlot> dateSlots, final Collection<TimeSlot> timeSlots);
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #645 

## 📝 작업 내용

- **배치 삽입을 위한 JdbcTemplate 도입**
IDENTITY 전략은 배치 기능을 비활성화시키고 JPA의 saveAll을 통한 배치 삽입은 ID 생성 전략이 SEQUENCE일 때 가장 효율적이기 때문에 DateSlot과 TimeSlot을 SEQUENCE 전략을 가진 엔티티로 관리하는 대신, JdbcTemplate을 활용해 직접적인 배치 삽입 로직을 구현했습니다.

- **저장 로직 순서 변경**
Room 엔티티를 먼저 저장하여 room_id를 확정한 후, 이 id를 이용해 관련된 모든 DateSlot과 TimeSlot 레코드를 배치 처리하도록 저장 로직을 수정했습니다.

- **배치 사이즈 최적화**
하루에 생성될 수 있는 시간 슬롯의 최대 개수는 30분 단위 기준 48개(24 * 2)이므로 모든 슬롯이 단일 배치로 처리될 수 있도록 배치 사이즈는 50으로 설정했습니다.

- **배치 동작 확인**
애플리케이션 로그 레벨을 TRACE로 설정해도, JDBC 드라이버 레벨에서 최종적으로 재작성되는 배치 쿼리 확인이 어려웠습니다. MySQL의 General Query Log를 직접 활성화해 다수의 INSERT문이 단일 Multi-Value INSERT 쿼리로 실행되는 것을 확인했습니다.
  ``` sql
  2025-10-06T08:46:23.376355Z       262 Query     SET autocommit=0
  2025-10-06T08:46:23.394532Z       262 Query     insert into room (active,deadline,session,title) values (1,'2025-10-07 16:30:00','0N5MK38JE9XG7','test')
  2025-10-06T08:46:23.405447Z       262 Query     SELECT @@session.transaction_read_only
  2025-10-06T08:46:23.410651Z       262 Query     INSERT INTO room_available_date_slot (room_id, start_at) VALUES (3, '2025-10-07'),(3, '2025-10-08'),(3, '2025-10-09')
  2025-10-06T08:46:23.413061Z       262 Query     SELECT @@session.transaction_read_only
  2025-10-06T08:46:23.417063Z       262 Query     INSERT INTO room_available_time_slot (room_id, start_at) VALUES (3, '00:00:00'),(3, '00:30:00'),(3, '01:00:00'),(3, '01:30:00'),(3, '02:00:00'),(3, '02:30:00'),(3, '03:00:00'),(3, '03:30:00'),(3, '04:00:00'),(3, '04:30:00'),(3, '05:00:00'),(3, '05:30:00'),(3, '06:00:00'),(3, '06:30:00'),(3, '07:00:00'),(3, '07:30:00'),(3, '08:00:00'),(3, '08:30:00'),(3, '09:00:00'),(3, '09:30:00'),(3, '10:00:00'),(3, '10:30:00'),(3, '11:00:00'),(3, '11:30:00'),(3, '12:00:00'),(3, '12:30:00'),(3, '13:00:00'),(3, '13:30:00'),(3, '14:00:00'),(3, '14:30:00'),(3, '15:00:00'),(3, '15:30:00'),(3, '16:00:00'),(3, '16:30:00'),(3, '17:00:00'),(3, '17:30:00'),(3, '18:00:00'),(3, '18:30:00'),(3, '19:00:00'),(3, '19:30:00'),(3, '20:00:00'),(3, '20:30:00'),(3, '21:00:00'),(3, '21:30:00'),(3, '22:00:00'),(3, '22:30:00'),(3, '23:00:00'),(3, '23:30:00')
  2025-10-06T08:46:23.426972Z       262 Query     COMMIT
  ```

- **패키지 구조 위치**
추후에 application의 repository 패키지가 core 패키지로 이동하는 점을 고려해 배치 삽입을 담당하는 SlotInsertRepository는 application 패키지 대신 core 패키지에 작성했습니다. 

- **JDBC URL 옵션 추가**
.env의 JDBC URL 옵션을 추가한 버전으로 업데이트했습니다. 코드 리뷰 후 GitHub Secrets를 업데이트할 예정입니다.

## 💬 리뷰 요구사항
